### PR TITLE
Log warning for not renewing from 60 to 30

### DIFF
--- a/ee/cli/plugins/site.py
+++ b/ee/cli/plugins/site.py
@@ -1175,7 +1175,7 @@ class EESiteUpdateController(CementBaseController):
                 if (expiry_days <= min_expiry_days):
                     renewLetsEncrypt(self,ee_domain)
                 else:
-                    Log.error(self,"More than 60 days left for certificate Expiry. Not renewing now.")
+                    Log.error(self,"More than 30 days left for certificate Expiry. Not renewing now.")
 
             else:
                 Log.error(self,"Cannot RENEW ! SSL is not configured for given site .")


### PR DESCRIPTION
`min_expiry_days` is set to 30 days, but the log warning says 60.