### PR TITLE
Use $http_host instead of $host for cache keys

### DIFF
--- a/ee/cli/templates/fastcgi.mustache
+++ b/ee/cli/templates/fastcgi.mustache
@@ -1,6 +1,6 @@
 # FastCGI cache settings
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=WORDPRESS:50m inactive=60m;
-fastcgi_cache_key "$scheme$request_method$host$request_uri";
+fastcgi_cache_key "$scheme$request_method$http_host$request_uri";
 fastcgi_cache_use_stale error timeout invalid_header updating http_500 http_503;
 fastcgi_cache_valid 200 301 302 404 1h;
 fastcgi_buffers 16 16k;

--- a/ee/cli/templates/redis-hhvm.mustache
+++ b/ee/cli/templates/redis-hhvm.mustache
@@ -36,7 +36,7 @@ location /redis-store {
 }
 
 location ~ \.php$ {
-  set $key "nginx-cache:$scheme$request_method$host$request_uri";
+  set $key "nginx-cache:$scheme$request_method$http_host$request_uri";
   try_files $uri =404;
 
   srcache_fetch_skip $skip_cache;

--- a/ee/cli/templates/redis-php7.mustache
+++ b/ee/cli/templates/redis-php7.mustache
@@ -35,7 +35,7 @@ location /redis-store {
 }
 
 location ~ \.php$ {
-  set $key "nginx-cache:$scheme$request_method$host$request_uri";
+  set $key "nginx-cache:$scheme$request_method$http_host$request_uri";
   try_files $uri =404;
 
   srcache_fetch_skip $skip_cache;

--- a/ee/cli/templates/redis.mustache
+++ b/ee/cli/templates/redis.mustache
@@ -36,7 +36,7 @@ location /redis-store {
 }
 
 location ~ \.php$ {
-  set $key "nginx-cache:$scheme$request_method$host$request_uri";
+  set $key "nginx-cache:$scheme$request_method$http_host$request_uri";
   try_files $uri =404;
 
   srcache_fetch_skip $skip_cache;

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -32,6 +32,6 @@ location ~ \.php$ {
   fastcgi_cache WORDPRESS;
 }
 location ~ /purge(/.*) {
-  fastcgi_cache_purge WORDPRESS "$scheme$request_method$host$1";
+  fastcgi_cache_purge WORDPRESS "$scheme$request_method$http_host$1";
   access_log off;
 }

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -32,6 +32,6 @@ location ~ \.php$ {
   fastcgi_cache WORDPRESS;
 }
 location ~ /purge(/.*) {
-  fastcgi_cache_purge WORDPRESS "$scheme$request_method$host$1";
+  fastcgi_cache_purge WORDPRESS "$scheme$request_method$http_host$1";
   access_log off;
 }

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -32,6 +32,6 @@ location ~ \.php$ {
   fastcgi_cache WORDPRESS;
 }
 location ~ /purge(/.*) {
-  fastcgi_cache_purge WORDPRESS "$scheme$request_method$host$1";
+  fastcgi_cache_purge WORDPRESS "$scheme$request_method$http_host$1";
   access_log off;
 }


### PR DESCRIPTION
$http_host is case sensitive so reduces the chance of cache key collisions

Fixes #705 
