### PR TITLE
Harden HTTPS configuration

### DIFF
--- a/ee/cli/plugins/site_functions.py
+++ b/ee/cli/plugins/site_functions.py
@@ -1388,6 +1388,9 @@ def setupLetsEncrypt(self, ee_domain_name):
                                      "ssl on;\n"
                                      "ssl_certificate     /etc/letsencrypt/live/{0}/fullchain.pem;\n"
                                      "ssl_certificate_key     /etc/letsencrypt/live/{0}/privkey.pem;\n"
+                                     "ssl_protocols TLSv1.2 TLSv1.1 TLSv1;\n"
+                                     "ssl_ciphers EECDH+AESGCM:EECDH+AES;\n"
+                                     "ssl_ecdh_curve secp384r1;\n"
                                      .format(ee_domain_name))
             sslconf.close()
             # updateSiteInfo(self, ee_domain_name, ssl=True)


### PR DESCRIPTION
ee is using the default Nginx HTTPS configuration, which is bad.

![screenshot_19-06-2016_auo50hwe](https://cloud.githubusercontent.com/assets/11699655/16176817/ed7b3598-3619-11e6-9a5c-6e33bad80874.png)

In this pull request I disabled DES3,  CAMELLIA256 and the 1024 bits DH, and added an AES and ECDH only cipher suite + 384 bits ECDH

This has no impact on the client compatibility.
