### PR TITLE
Woocommerce: Cache shows cart items from other users

### DIFF
--- a/ee/cli/templates/redis-hhvm.mustache
+++ b/ee/cli/templates/redis-hhvm.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/redis-php7.mustache
+++ b/ee/cli/templates/redis-php7.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/redis.mustache
+++ b/ee/cli/templates/redis.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc-hhvm.mustache
+++ b/ee/cli/templates/w3tc-hhvm.mustache
@@ -13,8 +13,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc-php7.mustache
+++ b/ee/cli/templates/w3tc-php7.mustache
@@ -13,8 +13,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc.mustache
+++ b/ee/cli/templates/w3tc.mustache
@@ -13,8 +13,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $skip_cache 1;
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc-hhvm.mustache
+++ b/ee/cli/templates/wpsc-hhvm.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc-php7.mustache
+++ b/ee/cli/templates/wpsc-php7.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc.mustache
+++ b/ee/cli/templates/wpsc.mustache
@@ -12,8 +12,8 @@ if ($query_string != "") {
 if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
   set $cache_uri 'null cache';
 }
-# Don't use the cache for logged in users or recent commenter
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in") {
+# Don't use the cache for logged in users or recent commenter or customer with items in cart
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress


### PR DESCRIPTION
If the woocoomerce cookie for the cart is set the user shouldn't get pages from cache, so added the woocommerce cookie to the skip cache rules for nginx.