### PR TITLE
Update how W3TC minified CSS/JS is supported.

### DIFF
--- a/ee/cli/templates/w3tc-hhvm.mustache
+++ b/ee/cli/templates/w3tc-hhvm.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/w3tc-hhvm.mustache
+++ b/ee/cli/templates/w3tc-hhvm.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/w3tc-php7.mustache
+++ b/ee/cli/templates/w3tc-php7.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/w3tc-php7.mustache
+++ b/ee/cli/templates/w3tc-php7.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/w3tc.mustache
+++ b/ee/cli/templates/w3tc.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/w3tc.mustache
+++ b/ee/cli/templates/w3tc.mustache
@@ -22,7 +22,7 @@ location / {
   try_files /wp-content/cache/page_enhanced/${host}${cache_uri}_index.html $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /index.php;
+  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1 /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -21,7 +21,7 @@ location / {
   try_files $uri $uri/ /index.php?$args;
 }
 location ~ ^/wp-content/cache/minify/(.+\.(css|js))$ {
-  try_files $uri /wp-content/plugins/w3-total-cache/pub/minify.php?file=$1;
+  try_files $uri /index.php;
 }
 location ~ \.php$ {
   try_files $uri =404;


### PR DESCRIPTION
W3 Total Cache removed `pub/minify.php` in version 0.9.5. Based on their suggested `nginx.conf` file they now redirect requests for minified CSS/JS files to `/index.php` instead.

Check out their their SVN repo via the plugin's [developers page](https://wordpress.org/plugins/w3-total-cache/developers/) on WordPress to verify the missing _pub/minify.php_ file. 

I discovered W3TC is now rewriting to `/index.php` by looking at the `/nginx.conf` file they create in the website root after changing minify settings.
