### PR TITLE
Ported command 'ee secure'

### DIFF
--- a/php/commands/secure.php
+++ b/php/commands/secure.php
@@ -69,7 +69,6 @@ class Secure_Command extends EE_Command {
 	public static function secure_ip(){
 		//***This function Secures IP***
 		//todo:
-		$newiplist = array();
 		$rawips = EE::input_value("Enter the comma separated Ip addresses to white list [127.0.0.1]:");
 		$ips = explode(",",$rawips);
 		if( !empty($ips) ){

--- a/php/commands/secure.php
+++ b/php/commands/secure.php
@@ -58,6 +58,23 @@ class Secure_Command extends EE_Command {
 	public static function secure_ip(){
 		//***This function Secures IP***
 		//todo:
+		$newiplist = array();
+		$rawips = EE::input_value("Enter the comma separated Ip addresses to white list [127.0.0.1]:");
+		$ips = explode(",",$rawips);
+		if( !empty($ips) ){
+			foreach($ips as $index => $ip){
+				$ip = trim($ip);
+				if (!filter_var($ip, FILTER_VALIDATE_IP) === false) {
+					EE::exec_cmd("sed -i \"/deny/i allow $ip;\" /etc/nginx/common/acl.conf");
+				} else {
+					echo("$ip is not a valid IP address");
+				}
+			}
+		}
+		EE_Git::add("/etc/nginx","Adding white listed to git");
+		EE_Service::restart_service("nginx");
+		EE::log("Successfully added IP address in acl.conf file");
+
 
 	}
 

--- a/php/commands/secure.php
+++ b/php/commands/secure.php
@@ -36,6 +36,23 @@ class Secure_Command extends EE_Command {
 		//***This function Secures port***
 		//todo:
 
+		EE::info("Please Enter valid port number");
+		$port = EE::input_value("EasyEngine admin port [22222]:");
+		if(empty($port)){
+			$port = 22222;
+		}
+		while(!is_numeric($port)){
+			EE::error("Please enter valid port number:");
+			$port = EE::input_value("EasyEngine admin port [22222]:");
+		}
+		$distro_name = EE_OS::ee_platform_distro();
+		if("ubuntu" == $distro_name) {
+			EE::exec_cmd("sed -i \"s/listen.*/listen $port default_server ssl http2;/\" /etc/nginx/sites-available/22222");
+		} else if ( "debian" == $distro_name){
+			EE::exec_cmd("sed -i \"s/listen.*/listen $port default_server ssl http2;/\" /etc/nginx/sites-available/22222");
+		}
+		EE_Git::add("/etc/nginx","Adding changed port to git");
+		EE_Service::restart_service("nginx");
 	}
 
 	public static function secure_ip(){
@@ -82,4 +99,3 @@ class Secure_Command extends EE_Command {
 }
 
 EE::add_command( 'secure', 'Secure_Command' );
-

--- a/php/commands/secure.php
+++ b/php/commands/secure.php
@@ -39,19 +39,30 @@ class Secure_Command extends EE_Command {
 		EE::info("Please Enter valid port number");
 		$port = EE::input_value("EasyEngine admin port [22222]:");
 		if(empty($port)){
+			EE::debug("No port selected using default port : 22222");
 			$port = 22222;
 		}
+		
 		while(!is_numeric($port)){
+			EE::debug("Not a valid port");
 			EE::error("Please enter valid port number:");
 			$port = EE::input_value("EasyEngine admin port [22222]:");
 		}
+		EE::debug("Checking distro of the machine");
 		$distro_name = EE_OS::ee_platform_distro();
+		EE::debug("$distro_name found");
 		if("ubuntu" == $distro_name) {
+			EE::debug("Changing nginx configuration");
 			EE::exec_cmd("sed -i \"s/listen.*/listen $port default_server ssl http2;/\" /etc/nginx/sites-available/22222");
 		} else if ( "debian" == $distro_name){
+			EE::debug("Changing nginx configuration");
 			EE::exec_cmd("sed -i \"s/listen.*/listen $port default_server ssl http2;/\" /etc/nginx/sites-available/22222");
+		} else {
+			EE::error("Unknown enviorment found");
 		}
+		EE::debug("Adding changes to git");
 		EE_Git::add("/etc/nginx","Adding changed port to git");
+		EE::debug("Restarting nginx");
 		EE_Service::restart_service("nginx");
 	}
 
@@ -64,16 +75,20 @@ class Secure_Command extends EE_Command {
 		if( !empty($ips) ){
 			foreach($ips as $index => $ip){
 				$ip = trim($ip);
+				EE::debug("Validating IP Address:$ip");
 				if (!filter_var($ip, FILTER_VALIDATE_IP) === false) {
+					EE::debug("Valid IP Address:$ip, adding it to acl.conf");
 					EE::exec_cmd("sed -i \"/deny/i allow $ip;\" /etc/nginx/common/acl.conf");
 				} else {
-					echo("$ip is not a valid IP address");
+					EE::Error("$ip is not a valid IP address. Skipping for now");
 				}
 			}
 		}
+		
 		EE_Git::add("/etc/nginx","Adding white listed to git");
+		EE::debug("Restarting nginx");
 		EE_Service::restart_service("nginx");
-		EE::log("Successfully added IP address in acl.conf file");
+		EE::log("Successfully added IP address(es) in acl.conf file");
 
 
 	}


### PR DESCRIPTION
As `ee secure --port` and `ee secure --ip` was not at all implemented,
I ported command `ee secure --port` and `ee secure --ip` which is linked down below,
>https://easyengine.io/docs/commands/secure/