### PR TITLE
Add Ubuntu 16.04 LTS in the compatible OS list

### DIFF
--- a/install
+++ b/install
@@ -65,7 +65,7 @@ fi
 # EasyEngine (ee) only support all Ubuntu/Debian distro except the distro reached EOL
 lsb_release -d | egrep -e "12.04|14.04|16.04|wheezy|jessie" &>> /dev/null
 if [ "$?" -ne "0" ]; then
-    ee_lib_echo_fail "EasyEngine (ee) only support Ubuntu 12.04/14.04 and Debian 7.x/8.x"
+    ee_lib_echo_fail "EasyEngine (ee) only support Ubuntu 12.04/14.04/16.04 LTS and Debian 7.x/8.x"
     exit 100
 fi
 


### PR DESCRIPTION
Issue was reported on EE Community Forum : 
http://community.rtcamp.com/t/ubunut-17-04-or-17-10/9753 