### PR TITLE
Better fail-safe everyday at 00:00 ssl "Lets Encrypt" renewal time

### DIFF
--- a/install
+++ b/install
@@ -694,7 +694,7 @@ if [ -f /etc/ImageMagick/policy.xml  ]
    if [[ $? -eq 0 ]]; then
         crontab -l > /var/spool/cron/cron-backup.txt  #backup cron before editing
         crontab -l | sed '/--min_expiry_limit/d' | crontab -
-        /bin/bash -c "crontab -l 2> /dev/null | { cat; echo -e \"\n0 0 * * 0 ee site update --le=renew --all 2> /dev/null # Renew all letsencrypt SSL cert. Set by EasyEngine\"; } | crontab -"
+        /bin/bash -c "crontab -l 2> /dev/null | { cat; echo -e \"\n0 0 * * * sudo ee site update --le=renew --all 2> /dev/null # Renew all letsencrypt SSL cert. Set by EasyEngine\"; } | crontab -"
    fi
 
 

--- a/install
+++ b/install
@@ -694,7 +694,7 @@ if [ -f /etc/ImageMagick/policy.xml  ]
    if [[ $? -eq 0 ]]; then
         crontab -l > /var/spool/cron/cron-backup.txt  #backup cron before editing
         crontab -l | sed '/--min_expiry_limit/d' | crontab -
-        /bin/bash -c "crontab -l 2> /dev/null | { cat; echo -e \"\n0 0 * * * sudo ee site update --le=renew --all 2> /dev/null # Renew all letsencrypt SSL cert. Set by EasyEngine\"; } | crontab -"
+        /bin/bash -c "crontab -l 2> /dev/null | { cat; echo -e \"\n0 0 * * * ee site update --le=renew --all 2> /dev/null # Renew all letsencrypt SSL cert. Set by EasyEngine\"; } | crontab -"
    fi
 
 


### PR DESCRIPTION
Fixed bugs #773 - SSL Lets Encrypt auto cron renewal was changed from once a week on sunday at 00:00 to everyday at 00:00. Sometimes some sites will have different times and sometimes can server have longer unexpected bugs for witch server has been down, so on up it would get ssl on first day.
https://easyengine.io/docs/lets-encrypt/
