### PR TITLE
Use limit_req to address load-scripts/styles.php issue CVE-2018-6389

### DIFF
--- a/ee/cli/templates/locations-php7.mustache
+++ b/ee/cli/templates/locations-php7.mustache
@@ -46,7 +46,7 @@ location /nginx_status {
   access_log off;
   include common/acl.conf;
 }
-location ~ ^/(status|ping) {
+location ~ ^/(status|ping)$ {
   include fastcgi_params;
   fastcgi_pass php7;
   include common/acl.conf;

--- a/ee/cli/templates/locations.mustache
+++ b/ee/cli/templates/locations.mustache
@@ -46,7 +46,7 @@ location /nginx_status {
   access_log off;
   include common/acl.conf;
 }
-location ~ ^/(status|ping) {
+location ~ ^/(status|ping)$ {
   include fastcgi_params;
   fastcgi_pass php;
   include common/acl.conf;

--- a/ee/cli/templates/redis-hhvm.mustache
+++ b/ee/cli/templates/redis-hhvm.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/redis-php7.mustache
+++ b/ee/cli/templates/redis-php7.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/redis.mustache
+++ b/ee/cli/templates/redis.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/w3tc-php7.mustache
+++ b/ee/cli/templates/w3tc-php7.mustache
@@ -10,7 +10,7 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpcommon-php7.mustache
+++ b/ee/cli/templates/wpcommon-php7.mustache
@@ -6,6 +6,22 @@ location = /wp-login.php {
   include fastcgi_params;
   fastcgi_pass php7;
 }
+location = /xmlrpc.php {
+  limit_req zone=one burst=1 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php7;
+}
+# limit access to avoid resource exhaustion attack CVE-2018-6389
+location = /wp-admin/load-scripts.php {
+  limit_req zone=one burst=3 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php7;
+}
+location = /wp-admin/load-styles.php {
+  limit_req zone=one burst=3 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php7;
+}
 # Disable wp-config.txt
 location = /wp-config.txt {
   deny all;

--- a/ee/cli/templates/wpcommon.mustache
+++ b/ee/cli/templates/wpcommon.mustache
@@ -6,6 +6,22 @@ location = /wp-login.php {
   include fastcgi_params;
   fastcgi_pass php;
 }
+location = /xmlrpc.php {
+  limit_req zone=one burst=1 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php;
+}
+# limit access to avoid resource exhaustion attack CVE-2018-6389
+location = /wp-admin/load-scripts.php {
+  limit_req zone=one burst=3 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php;
+}
+location = /wp-admin/load-styles.php {
+  limit_req zone=one burst=3 nodelay;
+  include fastcgi_params;
+  fastcgi_pass php;
+}
 # Disable wp-config.txt
 location = /wp-config.txt {
   deny all;

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpsc-hhvm.mustache
+++ b/ee/cli/templates/wpsc-hhvm.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpsc-php7.mustache
+++ b/ee/cli/templates/wpsc-php7.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart

--- a/ee/cli/templates/wpsc.mustache
+++ b/ee/cli/templates/wpsc.mustache
@@ -9,7 +9,7 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
+if ($request_uri ~* "(/wp-admin/|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart


### PR DESCRIPTION
Adding locations with limit_req rules to the wpcommon config files as proposed on https://community.rtcamp.com/t/use-limit-req-to-address-load-scripts-styles-php-issue-cve-2018-6389/10161 to:
1. limit requests to load-scripts.php and load-styles.php for resource exhaustion prevention CVE-2018-6389
2. limit request to xmlrpc.php for brute force protection

Due to 2, the  xmlrpc.php can be removed from the regular expressions that set the $skip_cache flag.