### PR TITLE
All URI starting with /status, /ping, /pma, /adminer etc. are treated as special locations

### DIFF
--- a/ee/cli/templates/locations-php7.mustache
+++ b/ee/cli/templates/locations-php7.mustache
@@ -46,7 +46,7 @@ location /nginx_status {
   access_log off;
   include common/acl.conf;
 }
-location ~ ^/(status|ping) {
+location ~ ^/(status|ping)$ {
   include fastcgi_params;
   fastcgi_pass php7;
   include common/acl.conf;

--- a/ee/cli/templates/locations-php7.mustache
+++ b/ee/cli/templates/locations-php7.mustache
@@ -41,7 +41,7 @@ if ($uri ~* "^.+(readme|license|example)\.(txt|html)$") {
   return 403;
 }
 # Status pages
-location /nginx_status {
+location = /nginx_status {
   stub_status on;
   access_log off;
   include common/acl.conf;
@@ -53,16 +53,16 @@ location ~ ^/(status|ping)$ {
 }
 # EasyEngine (ee) utilities
 # phpMyAdmin settings
-location /pma {
+location = /pma {
   return 301 https://$host:22222/db/pma;
 }
-location /phpMyAdmin {
+location = /phpMyAdmin {
   return 301 https://$host:22222/db/pma;
 }
-location /phpmyadmin {
+location = /phpmyadmin {
   return 301 https://$host:22222/db/pma;
 }
 # Adminer settings
-location /adminer {
+location = /adminer {
   return 301 https://$host:22222/db/adminer;
 }

--- a/ee/cli/templates/locations.mustache
+++ b/ee/cli/templates/locations.mustache
@@ -46,7 +46,7 @@ location /nginx_status {
   access_log off;
   include common/acl.conf;
 }
-location ~ ^/(status|ping) {
+location ~ ^/(status|ping)$ {
   include fastcgi_params;
   fastcgi_pass php;
   include common/acl.conf;

--- a/ee/cli/templates/locations.mustache
+++ b/ee/cli/templates/locations.mustache
@@ -41,7 +41,7 @@ if ($uri ~* "^.+(readme|license|example)\.(txt|html)$") {
   return 403;
 }
 # Status pages
-location /nginx_status {
+location = /nginx_status {
   stub_status on;
   access_log off;
   include common/acl.conf;
@@ -53,16 +53,16 @@ location ~ ^/(status|ping)$ {
 }
 # EasyEngine (ee) utilities
 # phpMyAdmin settings
-location /pma {
+location = /pma {
   return 301 https://$host:22222/db/pma;
 }
-location /phpMyAdmin {
+location = /phpMyAdmin {
   return 301 https://$host:22222/db/pma;
 }
-location /phpmyadmin {
+location = /phpmyadmin {
   return 301 https://$host:22222/db/pma;
 }
 # Adminer settings
-location /adminer {
+location = /adminer {
   return 301 https://$host:22222/db/adminer;
 }


### PR DESCRIPTION
Say someone writes a page or post about the game Ping Pong or a television animation Pingu or an urban dictionary about PMA (Positive Mental Attitude). It'd be likely that page slug would start with "ping" or "pma". In such a case, visiting that page would give an unexpected result.

This can be prevented by making the location directives in locations.conf and locations-php7.conf more strict by:

- terminating the location regex for /ping and /status with a $
- adding = to location directives /pma, /adminer etc.