### PR TITLE
Fix pymysql related error

### DIFF
--- a/ee/core/mysql.py
+++ b/ee/core/mysql.py
@@ -133,5 +133,4 @@ class EEMysql():
             return False
         except MySQLConnectionError as e:
             Log.debug(self, str(e))
-            raise MySQLConnectionError
-            #return False
+            return False


### PR DESCRIPTION
PyMySQL is not a drop in replacement for pymysql3 and as such it throws different exceptions. We are creating our own exceptions and when pymysql3 was replaced by PyMySQL, we were not returning the correct value in one situation. #969 

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>