### PR TITLE
Add CI build for docker images and update to wp-command

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -52,5 +52,11 @@ sha512sum $fname | cut -d ' ' -f 1 > $fname.sha512
 
 git add .
 git commit -m "phar build: $TRAVIS_REPO_SLUG@$TRAVIS_COMMIT"
-
 git push
+
+# Trigger docker image build with new phar
+if [[ "$TRAVIS_BRANCH" == "develop-v4" ]]; then
+	curl -H "Content-Type: application/json" --data '{"docker_tag": "nightly"}' -X POST https://registry.hub.docker.com/u/easyengine/base/trigger/"$DOCKER_BUILD_TOKEN"/
+else
+	curl -H "Content-Type: application/json" --data '{"docker_tag": "latest"}' -X POST https://registry.hub.docker.com/u/easyengine/base/trigger/"$DOCKER_BUILD_TOKEN"/
+fi

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -56,7 +56,7 @@ git push
 
 # Trigger docker image build with new phar
 if [[ "$TRAVIS_BRANCH" == "develop-v4" ]]; then
-	curl -H "Content-Type: application/json" --data '{"docker_tag": "nightly"}' -X POST https://registry.hub.docker.com/u/easyengine/base/trigger/"$DOCKER_BUILD_TOKEN"/
-else
 	curl -H "Content-Type: application/json" --data '{"docker_tag": "latest"}' -X POST https://registry.hub.docker.com/u/easyengine/base/trigger/"$DOCKER_BUILD_TOKEN"/
+else
+	curl -H "Content-Type: application/json" --data '{"docker_tag": "stable"}' -X POST https://registry.hub.docker.com/u/easyengine/base/trigger/"$DOCKER_BUILD_TOKEN"/
 fi

--- a/composer.lock
+++ b/composer.lock
@@ -310,12 +310,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/EasyEngine/wp-command.git",
-                "reference": "4eb2ddd64e2fe8485dfb5a31bb3da4864fd0b792"
+                "reference": "24671d90ebf141ee690199388ba99ff44a54b5e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/EasyEngine/wp-command/zipball/4eb2ddd64e2fe8485dfb5a31bb3da4864fd0b792",
-                "reference": "4eb2ddd64e2fe8485dfb5a31bb3da4864fd0b792",
+                "url": "https://api.github.com/repos/EasyEngine/wp-command/zipball/24671d90ebf141ee690199388ba99ff44a54b5e5",
+                "reference": "24671d90ebf141ee690199388ba99ff44a54b5e5",
                 "shasum": ""
             },
             "type": "ee-cli-package",
@@ -341,7 +341,7 @@
                 "MIT"
             ],
             "homepage": "https://github.com/easyengine/wp-command",
-            "time": "2018-04-06T15:37:41+00:00"
+            "time": "2018-04-11T12:21:55+00:00"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
Update `.travis.yml` to incorporate automatic docker image building with the latest `phar` as soon as the new `phar` is generated. 