### PR TITLE
Replace deprecated urlretrieve() with request.urlopen()

### DIFF
--- a/ee/core/download.py
+++ b/ee/core/download.py
@@ -22,7 +22,9 @@ class EEDownload():
                 if not os.path.exists(directory):
                     os.makedirs(directory)
                 Log.info(self, "Downloading {0:20}".format(pkg_name), end=' ')
-                urllib.request.urlretrieve(url, filename)
+                req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+                with urllib.request.urlopen(req) as response, open(filename, 'wb') as out_file:
+                    out_file.write(response.read())
                 Log.info(self, "{0}".format("[" + Log.ENDC + "Done"
                                             + Log.OKBLUE + "]"))
             except urllib.error.URLError as e:


### PR DESCRIPTION
The urlretrieve function used to download the update script is deprecated. Plus rt.cx is now served over HTTPS and urlretrieve can't handle redirection.

Replaced the deprecated function with urlopen as it can also handle redirection.

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>