### PR TITLE
Fix update bug

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -259,7 +259,8 @@ class CLI_Command extends EE_Command {
 		if ( false === chmod( $temp, $mode ) ) {
 			EE::error( sprintf( 'Cannot chmod %s.', $temp ) );
 		}
-		class_exists( '\cli\Colors' ); // This autoloads \cli\Colors - after we move the file we no longer have access to this class.
+		class_exists( '\cli\Streams' ); // This autoloads \cli\Streams - after we move the file we no longer have access to this class.
+		class_exists( '\cli\Colors' ); // This autoloads \cli\Colors
 		if ( false === rename( $temp, $old_phar ) ) {
 			EE::error( sprintf( 'Cannot move %s to %s', $temp, $old_phar ) );
 		}


### PR DESCRIPTION
There's a bug in beta-1 release in which when you issue update, It threw error (but the update worked correctly). 

The error was thrown because after update, the phar is replaced and after that we're calling `EE::success` which triggers autoloading. The autoloader cannot find the class as the phar has been moved.

To solve it, we autoloaded the given class before the phar was moved.