### PR TITLE
Extend EE::launch to accomodate environment variables

### DIFF
--- a/php/class-ee.php
+++ b/php/class-ee.php
@@ -814,13 +814,13 @@ class EE {
 	 *
 	 * @return int|ProcessRun The command exit status, or a ProcessRun object for full details.
 	 */
-	public static function launch( $command, $exit_on_error = true, $return_detailed = false, $env = array(), $cwd = null ) {
+	public static function launch( $command, $exit_on_error = true, $return_detailed = false, $env = null, $cwd = null ) {
 		Utils\check_proc_available( 'launch' );
 
 		$proc    = Process::create( $command, $cwd, $env );
 		$results = $proc->run();
 
-		if ( - 1 == $results->return_code ) {
+		if ( -1 == $results->return_code ) {
 			self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
 		}
 

--- a/php/class-ee.php
+++ b/php/class-ee.php
@@ -803,21 +803,24 @@ class EE {
 	/**
 	 * Launch an arbitrary external process that takes over I/O.
 	 *
-	 * @access public
+	 * @access   public
 	 * @category Execution
 	 *
-	 * @param string $command External process to launch.
-	 * @param boolean $exit_on_error Whether to exit if the command returns an elevated return code.
+	 * @param string  $command         External process to launch.
+	 * @param boolean $exit_on_error   Whether to exit if the command returns an elevated return code.
 	 * @param boolean $return_detailed Whether to return an exit status (default) or detailed execution results.
+	 * @param array   $env             Environment variables to set when running the command.
+	 * @param string  $cwd             Directory to execute the command in.
+	 *
 	 * @return int|ProcessRun The command exit status, or a ProcessRun object for full details.
 	 */
-	public static function launch( $command, $exit_on_error = true, $return_detailed = false ) {
+	public static function launch( $command, $exit_on_error = true, $return_detailed = false, $env = array(), $cwd = null ) {
 		Utils\check_proc_available( 'launch' );
 
-		$proc = Process::create( $command );
+		$proc    = Process::create( $command, $cwd, $env );
 		$results = $proc->run();
 
-		if ( -1 == $results->return_code ) {
+		if ( - 1 == $results->return_code ) {
 			self::warning( "Spawned process returned exit code {$results->return_code}, which could be caused by a custom compiled version of PHP that uses the --enable-sigchild option." );
 		}
 

--- a/php/utils.php
+++ b/php/utils.php
@@ -1437,7 +1437,7 @@ function default_debug( $launch ) {
  *
  * @return bool True if executed successfully. False if failed.
  */
-function default_launch( $command, $env = array(), $cwd = null ) {
+function default_launch( $command, $env = null, $cwd = null ) {
 	$launch = EE::launch( $command, false, true, $env, $cwd );
 	default_debug( $launch );
 	if ( ! $launch->return_code ) {

--- a/php/utils.php
+++ b/php/utils.php
@@ -1381,12 +1381,16 @@ function delete_dir( $dir ) {
 
 /**
  * Function to generate random password.
+ *
+ * @param int $length Length of random password required.
+ *
+ * @return string Random Password of specified length.
  */
-function random_password() {
+function random_password( $length = 12 ) {
 	$alphabet    = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 	$pass        = array();
 	$alphaLength = strlen( $alphabet ) - 1;
-	for ( $i = 0; $i < 12; $i ++ ) {
+	for ( $i = 0; $i < $length; $i ++ ) {
 		$n      = rand( 0, $alphaLength );
 		$pass[] = $alphabet[$n];
 	}
@@ -1425,16 +1429,50 @@ function default_debug( $launch ) {
 
 /**
  * Default Launch command.
+ * This takes care of executing the command as well as debugging it to terminal as well as file.
  *
- * @param Object $launch EE::Launch command object
+ * @param string $command The command to be executed via EE::launch();
+ * @param array  $env     Environment variables to set when running the command.
+ * @param string $cwd     Directory to execute the command in.
+ *
+ * @return bool True if executed successfully. False if failed.
  */
-function default_launch( $command ) {
-	$launch = EE::launch( $command, false, true );
+function default_launch( $command, $env = array(), $cwd = null ) {
+	$launch = EE::launch( $command, false, true, $env, $cwd );
 	default_debug( $launch );
 	if ( ! $launch->return_code ) {
 		return true;
 	}
+
 	return false;
+}
+
+/**
+ * Function that takes care of executing the command as well as debugging it to terminal as well as file.
+ *
+ * @param string $command The command to be executed via exec();
+ *
+ * @return bool True if executed successfully. False if failed.
+ */
+function default_exec( $command ) {
+	exec( $command, $out, $return_code );
+	EE::debug( 'COMMAND: ' . $command );
+	EE::debug( 'STDOUT: ' . implode( $out ) );
+	EE::debug( 'RETURN CODE: ' . $return_code );
+	if ( ! $return_code ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Function that takes care of executing the command as well as debugging it to terminal as well as file.
+ *
+ * @param string $command The command to be executed via shell_exec();
+ */
+function default_shell_exec( $command ) {
+	EE::debug( 'COMMAND: ' . $command );
+	EE::debug( 'STDOUT: ' . shell_exec( $command ) );
 }
 
 /**


### PR DESCRIPTION
Extend `EE::launch` and `default_launch` functions to accommodate environment variables and working dir to execute the command in. 
Also have added `default_exec` and `default_shell_exec` functions in `utils` to execute `exec()` and `shell_exec()` with debugging and logging on terminal as well as file.