### PR TITLE
Update support for packaging site command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
         "easyengine/cron-command": "v1.0.0-beta.1",
         "easyengine/site-command": "v1.0.0",
         "easyengine/shell-command": "v1.0.0-beta.1",
+        "ext-openssl": "*",
+        "guzzlehttp/guzzle": "^6.0",
         "justinrainbow/json-schema": "~5.2.5",
+        "league/flysystem": "^1.0.19",
         "monolog/monolog": "^1.23",
         "mustache/mustache": "~2.4",
         "rmccue/requests": "~1.6",
@@ -42,8 +45,10 @@
         "symfony/filesystem": "^2.7|^3.0",
         "symfony/finder": "^2.7|^3.0",
         "symfony/process": "^2.1|^3.0",
+        "symfony/serializer": "^3.0",
         "symfony/translation": "^2.7|^3.0",
         "symfony/yaml": "^2.7|^3.0",
+        "webmozart/assert": "^1.0",
         "wp-cli/autoload-splitter": "^0.1.5",
         "wp-cli/mustangostang-spyc": "^0.6.3",
         "wp-cli/php-cli-tools": "~0.11.2"
@@ -64,7 +69,8 @@
             "EE": "php"
         },
         "psr-4": {
-            "": "php/commands/src"
+            "": "php/commands/src",
+            "AcmePhp\\Cli\\": "php/AcmePhp/Cli"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -3329,6 +3329,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "acmephp/core": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f237f357e6d5533ab44375b7878885b",
+    "content-hash": "2df550edcb8b8698bd6442f881302533",
     "packages": [
         {
             "name": "acmephp/core",
@@ -3329,13 +3329,13 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "acmephp/core": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "ext-openssl": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/php/AcmePhp/Cli/Exception/AcmeCliActionException.php
+++ b/php/AcmePhp/Cli/Exception/AcmeCliActionException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Exception;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class AcmeCliActionException extends AcmeCliException
+{
+    public function __construct($actionName, \Exception $previous = null)
+    {
+        parent::__construct(sprintf('An exception was thrown during action "%s"', $actionName), $previous);
+    }
+}

--- a/php/AcmePhp/Cli/Exception/AcmeCliException.php
+++ b/php/AcmePhp/Cli/Exception/AcmeCliException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Exception;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class AcmeCliException extends \RuntimeException
+{
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/php/AcmePhp/Cli/Exception/AcmeDnsResolutionException.php
+++ b/php/AcmePhp/Cli/Exception/AcmeDnsResolutionException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Exception;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class AcmeDnsResolutionException extends AcmeCliException
+{
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct(null === $message ? 'An exception was thrown during resolution of DNS' : $message, $previous);
+    }
+}

--- a/php/AcmePhp/Cli/Exception/CommandFlowException.php
+++ b/php/AcmePhp/Cli/Exception/CommandFlowException.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Exception;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class CommandFlowException extends AcmeCliException
+{
+    /**
+     * @var string
+     */
+    private $missing;
+    /**
+     * @var string
+     */
+    private $command;
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * @param string          $missing   Missing requirement to fix the flow
+     * @param string          $command   Name of the command to run in order to fix the flow
+     * @param array           $arguments Optional list of missing arguments
+     * @param \Exception|null $previous
+     */
+    public function __construct($missing, $command, array $arguments = [], \Exception $previous = null)
+    {
+        $this->missing = $missing;
+        $this->command = $command;
+        $this->arguments = $arguments;
+
+        $message = trim(sprintf(
+            'You have to %s first. Run the command%sphp %s %s %s',
+            $missing,
+            PHP_EOL.PHP_EOL,
+            $_SERVER['PHP_SELF'],
+            $command,
+            implode(' ', $arguments)
+        ));
+
+        parent::__construct($message, $previous);
+    }
+}

--- a/php/AcmePhp/Cli/Repository/Repository.php
+++ b/php/AcmePhp/Cli/Repository/Repository.php
@@ -1,0 +1,439 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Repository;
+
+use AcmePhp\Cli\Exception\AcmeCliException;
+use AcmePhp\Cli\Serializer\PemEncoder;
+use AcmePhp\Core\Protocol\AuthorizationChallenge;
+use AcmePhp\Core\Protocol\CertificateOrder;
+use AcmePhp\Ssl\Certificate;
+use AcmePhp\Ssl\CertificateResponse;
+use AcmePhp\Ssl\DistinguishedName;
+use AcmePhp\Ssl\KeyPair;
+use AcmePhp\Ssl\PrivateKey;
+use AcmePhp\Ssl\PublicKey;
+use League\Flysystem\FilesystemInterface;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class Repository implements RepositoryV2Interface
+{
+    const PATH_ACCOUNT_KEY_PRIVATE = 'account/key.private.pem';
+    const PATH_ACCOUNT_KEY_PUBLIC = 'account/key.public.pem';
+
+    const PATH_DOMAIN_KEY_PUBLIC = 'certs/{domain}/private/key.public.pem';
+    const PATH_DOMAIN_KEY_PRIVATE = 'certs/{domain}/private/key.private.pem';
+    const PATH_DOMAIN_CERT_CERT = 'certs/{domain}/public/cert.pem';
+    const PATH_DOMAIN_CERT_CHAIN = 'certs/{domain}/public/chain.pem';
+    const PATH_DOMAIN_CERT_FULLCHAIN = 'certs/{domain}/public/fullchain.pem';
+    const PATH_DOMAIN_CERT_COMBINED = 'certs/{domain}/private/combined.pem';
+
+    const PATH_CACHE_AUTHORIZATION_CHALLENGE = 'var/{domain}/authorization_challenge.json';
+    const PATH_CACHE_DISTINGUISHED_NAME = 'var/{domain}/distinguished_name.json';
+    const PATH_CACHE_CERTIFICATE_ORDER = 'var/{domains}/certificate_order.json';
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var FilesystemInterface
+     */
+    private $master;
+
+    /**
+     * @var FilesystemInterface
+     */
+    private $backup;
+
+    /**
+     * @var bool
+     */
+    private $enableBackup;
+
+    /**
+     * @param SerializerInterface $serializer
+     * @param FilesystemInterface $master
+     * @param FilesystemInterface $backup
+     * @param bool                $enableBackup
+     */
+    public function __construct(SerializerInterface $serializer, FilesystemInterface $master, FilesystemInterface $backup, $enableBackup)
+    {
+        $this->serializer = $serializer;
+        $this->master = $master;
+        $this->backup = $backup;
+        $this->enableBackup = $enableBackup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeCertificateResponse(CertificateResponse $certificateResponse)
+    {
+        $distinguishedName = $certificateResponse->getCertificateRequest()->getDistinguishedName();
+        $domain = $distinguishedName->getCommonName();
+
+        $this->storeDomainKeyPair($domain, $certificateResponse->getCertificateRequest()->getKeyPair());
+        $this->storeDomainDistinguishedName($domain, $distinguishedName);
+        $this->storeDomainCertificate($domain, $certificateResponse->getCertificate());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeAccountKeyPair(KeyPair $keyPair)
+    {
+        try {
+            $this->save(
+                self::PATH_ACCOUNT_KEY_PUBLIC,
+                $this->serializer->serialize($keyPair->getPublicKey(), PemEncoder::FORMAT)
+            );
+
+            $this->save(
+                self::PATH_ACCOUNT_KEY_PRIVATE,
+                $this->serializer->serialize($keyPair->getPrivateKey(), PemEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException('Storing of account key pair failed', $e);
+        }
+    }
+
+    private function getPathForDomain($path, $domain)
+    {
+        return strtr($path, ['{domain}' => $this->normalizeDomain($domain)]);
+    }
+
+    private function getPathForDomainList($path, array $domains)
+    {
+        return strtr($path, ['{domains}' => $this->normalizeDomainList($domains)]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAccountKeyPair()
+    {
+        return $this->master->has(self::PATH_ACCOUNT_KEY_PRIVATE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadAccountKeyPair()
+    {
+        try {
+            $publicKeyPem = $this->master->read(self::PATH_ACCOUNT_KEY_PUBLIC);
+            $privateKeyPem = $this->master->read(self::PATH_ACCOUNT_KEY_PRIVATE);
+
+            return new KeyPair(
+                $this->serializer->deserialize($publicKeyPem, PublicKey::class, PemEncoder::FORMAT),
+                $this->serializer->deserialize($privateKeyPem, PrivateKey::class, PemEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException('Loading of account key pair failed', $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeDomainKeyPair($domain, KeyPair $keyPair)
+    {
+        try {
+            $this->save(
+                $this->getPathForDomain(self::PATH_DOMAIN_KEY_PUBLIC, $domain),
+                $this->serializer->serialize($keyPair->getPublicKey(), PemEncoder::FORMAT)
+            );
+
+            $this->save(
+                $this->getPathForDomain(self::PATH_DOMAIN_KEY_PRIVATE, $domain),
+                $this->serializer->serialize($keyPair->getPrivateKey(), PemEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Storing of domain %s key pair failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDomainKeyPair($domain)
+    {
+        return $this->master->has($this->getPathForDomain(self::PATH_DOMAIN_KEY_PRIVATE, $domain));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadDomainKeyPair($domain)
+    {
+        try {
+            $publicKeyPem = $this->master->read($this->getPathForDomain(self::PATH_DOMAIN_KEY_PUBLIC, $domain));
+            $privateKeyPem = $this->master->read($this->getPathForDomain(self::PATH_DOMAIN_KEY_PRIVATE, $domain));
+
+            return new KeyPair(
+                $this->serializer->deserialize($publicKeyPem, PublicKey::class, PemEncoder::FORMAT),
+                $this->serializer->deserialize($privateKeyPem, PrivateKey::class, PemEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Loading of domain %s key pair failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeDomainAuthorizationChallenge($domain, AuthorizationChallenge $authorizationChallenge)
+    {
+        try {
+            $this->save(
+                $this->getPathForDomain(self::PATH_CACHE_AUTHORIZATION_CHALLENGE, $domain),
+                $this->serializer->serialize($authorizationChallenge, JsonEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Storing of domain %s authorization challenge failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDomainAuthorizationChallenge($domain)
+    {
+        return $this->master->has($this->getPathForDomain(self::PATH_CACHE_AUTHORIZATION_CHALLENGE, $domain));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadDomainAuthorizationChallenge($domain)
+    {
+        try {
+            $json = $this->master->read($this->getPathForDomain(self::PATH_CACHE_AUTHORIZATION_CHALLENGE, $domain));
+
+            return $this->serializer->deserialize($json, AuthorizationChallenge::class, JsonEncoder::FORMAT);
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Loading of domain %s authorization challenge failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeDomainDistinguishedName($domain, DistinguishedName $distinguishedName)
+    {
+        try {
+            $this->save(
+                $this->getPathForDomain(self::PATH_CACHE_DISTINGUISHED_NAME, $domain),
+                $this->serializer->serialize($distinguishedName, JsonEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Storing of domain %s distinguished name failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDomainDistinguishedName($domain)
+    {
+        return $this->master->has($this->getPathForDomain(self::PATH_CACHE_DISTINGUISHED_NAME, $domain));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadDomainDistinguishedName($domain)
+    {
+        try {
+            $json = $this->master->read($this->getPathForDomain(self::PATH_CACHE_DISTINGUISHED_NAME, $domain));
+
+            return $this->serializer->deserialize($json, DistinguishedName::class, JsonEncoder::FORMAT);
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Loading of domain %s distinguished name failed', $domain), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeDomainCertificate($domain, Certificate $certificate)
+    {
+        // Simple certificate
+        $certPem = $this->serializer->serialize($certificate, PemEncoder::FORMAT);
+
+        // Issuer chain
+        $issuerChain = [];
+        $issuerCertificate = $certificate->getIssuerCertificate();
+
+        while (null !== $issuerCertificate) {
+            $issuerChain[] = $this->serializer->serialize($issuerCertificate, PemEncoder::FORMAT);
+            $issuerCertificate = $issuerCertificate->getIssuerCertificate();
+        }
+
+        $chainPem = implode("\n", $issuerChain);
+
+        // Full chain
+        $fullChainPem = $certPem.$chainPem;
+
+        // Combined
+        $keyPair = $this->loadDomainKeyPair($domain);
+        $combinedPem = $fullChainPem.$this->serializer->serialize($keyPair->getPrivateKey(), PemEncoder::FORMAT);
+
+        // Save
+        $this->save($this->getPathForDomain(self::PATH_DOMAIN_CERT_CERT, $domain), $certPem);
+        $this->save($this->getPathForDomain(self::PATH_DOMAIN_CERT_CHAIN, $domain), $chainPem);
+        $this->save($this->getPathForDomain(self::PATH_DOMAIN_CERT_FULLCHAIN, $domain), $fullChainPem);
+        $this->save($this->getPathForDomain(self::PATH_DOMAIN_CERT_COMBINED, $domain), $combinedPem);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasDomainCertificate($domain)
+    {
+        return $this->master->has($this->getPathForDomain(self::PATH_DOMAIN_CERT_FULLCHAIN, $domain));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadDomainCertificate($domain)
+    {
+        try {
+            $pems = explode('-----BEGIN CERTIFICATE-----', $this->master->read($this->getPathForDomain(self::PATH_DOMAIN_CERT_FULLCHAIN, $domain)));
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Loading of domain %s certificate failed', $domain), $e);
+        }
+
+        $pems = array_map(function ($item) {
+            return trim(str_replace('-----END CERTIFICATE-----', '', $item));
+        }, $pems);
+        array_shift($pems);
+        $pems = array_reverse($pems);
+
+        $certificate = null;
+
+        foreach ($pems as $pem) {
+            $certificate = new Certificate(
+                "-----BEGIN CERTIFICATE-----\n".$pem."\n-----END CERTIFICATE-----",
+                $certificate
+            );
+        }
+
+        return $certificate;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeCertificateOrder(array $domains, CertificateOrder $order)
+    {
+        try {
+            $this->save(
+                $this->getPathForDomainList(self::PATH_CACHE_CERTIFICATE_ORDER, $domains),
+                $this->serializer->serialize($order, JsonEncoder::FORMAT)
+            );
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Storing of domains %s certificate order failed', implode(', ', $domains)), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCertificateOrder(array $domains)
+    {
+        return $this->master->has($this->getPathForDomainList(self::PATH_CACHE_CERTIFICATE_ORDER, $domains));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadCertificateOrder(array $domains)
+    {
+        try {
+            $json = $this->master->read($this->getPathForDomainList(self::PATH_CACHE_CERTIFICATE_ORDER, $domains));
+
+            return $this->serializer->deserialize($json, CertificateOrder::class, JsonEncoder::FORMAT);
+        } catch (\Exception $e) {
+            throw new AcmeCliException(sprintf('Loading of domains %s certificate order failed', implode(', ', $domains)), $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($path, $content, $visibility = self::VISIBILITY_PRIVATE)
+    {
+        if (!$this->master->has($path)) {
+            // File creation: remove from backup if it existed and warm-up both master and backup
+            $this->createAndBackup($path, $content);
+        } else {
+            // File update: backup before writing
+            $this->backupAndUpdate($path, $content);
+        }
+
+        if ($this->enableBackup) {
+            $this->backup->setVisibility($path, $visibility);
+        }
+
+        $this->master->setVisibility($path, $visibility);
+    }
+
+    private function createAndBackup($path, $content)
+    {
+        if ($this->enableBackup) {
+            if ($this->backup->has($path)) {
+                $this->backup->delete($path);
+            }
+
+            $this->backup->write($path, $content);
+        }
+
+        $this->master->write($path, $content);
+    }
+
+    private function backupAndUpdate($path, $content)
+    {
+        if ($this->enableBackup) {
+            $oldContent = $this->master->read($path);
+
+            if (false !== $oldContent) {
+                if ($this->backup->has($path)) {
+                    $this->backup->update($path, $oldContent);
+                } else {
+                    $this->backup->write($path, $oldContent);
+                }
+            }
+        }
+
+        $this->master->update($path, $content);
+    }
+
+    private function normalizeDomain($domain)
+    {
+        return $domain;
+    }
+
+    private function normalizeDomainList(array $domains)
+    {
+        $normalizedDomains = array_unique(array_map([$this, 'normalizeDomain'], $domains));
+        sort($normalizedDomains);
+
+        return (isset($domains[0]) ? $this->normalizeDomain($domains[0]) : '-').'/'.sha1(json_encode($normalizedDomains));
+    }
+}

--- a/php/AcmePhp/Cli/Repository/RepositoryInterface.php
+++ b/php/AcmePhp/Cli/Repository/RepositoryInterface.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Repository;
+
+use AcmePhp\Cli\Exception\AcmeCliException;
+use AcmePhp\Core\Protocol\AuthorizationChallenge;
+use AcmePhp\Ssl\Certificate;
+use AcmePhp\Ssl\CertificateResponse;
+use AcmePhp\Ssl\DistinguishedName;
+use AcmePhp\Ssl\KeyPair;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+interface RepositoryInterface
+{
+    const VISIBILITY_PUBLIC = 'public';
+    const VISIBILITY_PRIVATE = 'private';
+
+    /**
+     * Extract important elements from the given certificate response and store them
+     * in the repository.
+     *
+     * This method will use the distinguished name common name as a domain to store:
+     *      - the key pair
+     *      - the certificate request
+     *      - the certificate
+     *
+     * @param CertificateResponse $certificateResponse
+     *
+     * @throws AcmeCliException
+     */
+    public function storeCertificateResponse(CertificateResponse $certificateResponse);
+
+    /**
+     * Store a given key pair as the account key pair (the global key pair used to
+     * interact with the ACME server).
+     *
+     * @param KeyPair $keyPair
+     *
+     * @throws AcmeCliException
+     */
+    public function storeAccountKeyPair(KeyPair $keyPair);
+
+    /**
+     * Check if there is an account key pair in the repository.
+     *
+     * @return bool
+     */
+    public function hasAccountKeyPair();
+
+    /**
+     * Load the account key pair.
+     *
+     * @throws AcmeCliException
+     *
+     * @return KeyPair
+     */
+    public function loadAccountKeyPair();
+
+    /**
+     * Store a given key pair as associated to a given domain.
+     *
+     * @param string  $domain
+     * @param KeyPair $keyPair
+     *
+     * @throws AcmeCliException
+     */
+    public function storeDomainKeyPair($domain, KeyPair $keyPair);
+
+    /**
+     * Check if there is a key pair associated to the given domain in the repository.
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomainKeyPair($domain);
+
+    /**
+     * Load the key pair associated to a given domain.
+     *
+     * @param string $domain
+     *
+     * @throws AcmeCliException
+     *
+     * @return KeyPair
+     */
+    public function loadDomainKeyPair($domain);
+
+    /**
+     * Store a given authorization challenge as associated to a given domain.
+     *
+     * @param string                 $domain
+     * @param AuthorizationChallenge $authorizationChallenge
+     *
+     * @throws AcmeCliException
+     */
+    public function storeDomainAuthorizationChallenge($domain, AuthorizationChallenge $authorizationChallenge);
+
+    /**
+     * Check if there is an authorization challenge associated to the given domain in the repository.
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomainAuthorizationChallenge($domain);
+
+    /**
+     * Load the authorization challenge associated to a given domain.
+     *
+     * @param string $domain
+     *
+     * @throws AcmeCliException
+     *
+     * @return AuthorizationChallenge
+     */
+    public function loadDomainAuthorizationChallenge($domain);
+
+    /**
+     * Store a given distinguished name as associated to a given domain.
+     *
+     * @param string            $domain
+     * @param DistinguishedName $distinguishedName
+     *
+     * @throws AcmeCliException
+     */
+    public function storeDomainDistinguishedName($domain, DistinguishedName $distinguishedName);
+
+    /**
+     * Check if there is a distinguished name associated to the given domain in the repository.
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomainDistinguishedName($domain);
+
+    /**
+     * Load the distinguished name associated to a given domain.
+     *
+     * @param string $domain
+     *
+     * @throws AcmeCliException
+     *
+     * @return DistinguishedName
+     */
+    public function loadDomainDistinguishedName($domain);
+
+    /**
+     * Store a given certificate as associated to a given domain.
+     *
+     * @param string      $domain
+     * @param Certificate $certificate
+     *
+     * @throws AcmeCliException
+     */
+    public function storeDomainCertificate($domain, Certificate $certificate);
+
+    /**
+     * Check if there is a certificate associated to the given domain in the repository.
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasDomainCertificate($domain);
+
+    /**
+     * Load the certificate associated to a given domain.
+     *
+     * @param string $domain
+     *
+     * @throws AcmeCliException
+     *
+     * @return Certificate
+     */
+    public function loadDomainCertificate($domain);
+
+    /**
+     * Save a given string into a given path handling backup.
+     *
+     * @param string $path
+     * @param string $content
+     * @param string $visibility the visibilty to use for this file
+     */
+    public function save($path, $content, $visibility = self::VISIBILITY_PRIVATE);
+}

--- a/php/AcmePhp/Cli/Repository/RepositoryV2Interface.php
+++ b/php/AcmePhp/Cli/Repository/RepositoryV2Interface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Repository;
+
+use AcmePhp\Cli\Exception\AcmeCliException;
+use AcmePhp\Core\Protocol\CertificateOrder;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+interface RepositoryV2Interface extends RepositoryInterface
+{
+    /**
+     * Store a given certificate as associated to a given domain.
+     *
+     * @param array            $domains
+     * @param CertificateOrder $order
+     *
+     * @throws AcmeCliException
+     */
+    public function storeCertificateOrder(array $domains, CertificateOrder $order);
+
+    /**
+     * Check if there is a certificate associated to the given domain in the repository.
+     *
+     * @param string $domain
+     *
+     * @return bool
+     */
+    public function hasCertificateOrder(array $domains);
+
+    /**
+     * Load the certificate associated to a given domain.
+     *
+     * @param string $domain
+     *
+     * @throws AcmeCliException
+     *
+     * @return CertificateOrder
+     */
+    public function loadCertificateOrder(array $domains);
+}

--- a/php/AcmePhp/Cli/Serializer/PemEncoder.php
+++ b/php/AcmePhp/Cli/Serializer/PemEncoder.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Serializer;
+
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class PemEncoder implements EncoderInterface, DecoderInterface
+{
+    const FORMAT = 'pem';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encode($data, $format, array $context = [])
+    {
+        return trim($data)."\n";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decode($data, $format, array $context = [])
+    {
+        return trim($data)."\n";
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsEncoding($format)
+    {
+        return self::FORMAT === $format;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDecoding($format)
+    {
+        return self::FORMAT === $format;
+    }
+}

--- a/php/AcmePhp/Cli/Serializer/PemNormalizer.php
+++ b/php/AcmePhp/Cli/Serializer/PemNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Acme PHP project.
+ *
+ * (c) Titouan Galopin <galopintitouan@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AcmePhp\Cli\Serializer;
+
+use AcmePhp\Ssl\Certificate;
+use AcmePhp\Ssl\Key;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class PemNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $object->getPEM();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return new $class($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && ($data instanceof Certificate || $data instanceof Key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return is_string($data);
+    }
+}

--- a/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
+++ b/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
@@ -21,6 +21,7 @@ final class LoadSiteUtilityFunctions implements BootstrapStep {
 	public function process( BootstrapState $state ) {
 		require_once EE_ROOT . '/php/site-utils.php';
 		require_once EE_ROOT . '/php/class-ee-site-letsencrypt.php';
+		require_once EE_ROOT . '/php/class-ee-site-shutdown-handler.php';
 
 		return $state;
 	}

--- a/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
+++ b/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace EE\Bootstrap;
+
+/**
+ * Class LoadSiteUtilityFunctions.
+ *
+ * Loads the functions available through `EE\SiteUtils`.
+ *
+ * @package EE\Bootstrap
+ */
+final class LoadSiteUtilityFunctions implements BootstrapStep {
+
+	/**
+	 * Process this single bootstrapping step.
+	 *
+	 * @param BootstrapState $state Contextual state to pass into the step.
+	 *
+	 * @return BootstrapState Modified state to pass to the next step.
+	 */
+	public function process( BootstrapState $state ) {
+		require_once EE_ROOT . '/php/site-utils.php';
+
+		return $state;
+	}
+}

--- a/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
+++ b/php/EE/Bootstrap/LoadSiteUtilityFunctions.php
@@ -20,6 +20,7 @@ final class LoadSiteUtilityFunctions implements BootstrapStep {
 	 */
 	public function process( BootstrapState $state ) {
 		require_once EE_ROOT . '/php/site-utils.php';
+		require_once EE_ROOT . '/php/class-ee-site-letsencrypt.php';
 
 		return $state;
 	}

--- a/php/EE/Bootstrap/RouteSiteCommands.php
+++ b/php/EE/Bootstrap/RouteSiteCommands.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EE\Bootstrap;
+
+/**
+ * Class LaunchRunner.
+ *
+ * Kick off the Runner object that starts the actual commands.
+ *
+ * @package EE\Bootstrap
+ */
+final class RouteSiteCommands implements BootstrapStep {
+
+	/**
+	 * Process this single bootstrapping step.
+	 *
+	 * @param BootstrapState $state Contextual state to pass into the step.
+	 *
+	 * @return BootstrapState Modified state to pass to the next step.
+	 */
+	public function process( BootstrapState $state ) {
+		$runner = new RunnerInstance();
+		$runner()->route();
+
+		return $state;
+	}
+}

--- a/php/EE/Dispatcher/CommandFactory.php
+++ b/php/EE/Dispatcher/CommandFactory.php
@@ -68,7 +68,14 @@ class CommandFactory {
 	 */
 	private static function create_subcommand( $parent, $name, $callable, $reflection ) {
 		$doc_comment = self::get_doc_comment( $reflection );
-		$docparser = new \EE\DocParser( $doc_comment );
+		$docparser   = new \EE\DocParser( $doc_comment );
+
+		while ( $docparser->has_tag( 'inheritdoc' ) ) {
+			$inherited_method = $reflection->getDeclaringClass()->getParentClass()->getMethod( $reflection->name );
+
+			$doc_comment = self::get_doc_comment( $inherited_method );
+			$docparser   = new \EE\DocParser( $doc_comment );
+		}
 
 		if ( is_array( $callable ) ) {
 			if ( ! $name ) {

--- a/php/EE/Dispatcher/CommandFactory.php
+++ b/php/EE/Dispatcher/CommandFactory.php
@@ -120,11 +120,12 @@ class CommandFactory {
 		$container = new CompositeCommand( $parent, $name, $docparser );
 
 		foreach ( $reflection->getMethods() as $method ) {
-			if ( ! self::is_good_method( $method ) ) {
+			$method_docparser = new \EE\DocParser( self::get_doc_comment( $method ) );
+			if ( ! self::is_good_method( $method ) || self::should_ignore_method( $method_docparser ) ) {
 				continue;
 			}
 
-			$class = is_object( $callable ) ? $callable : $reflection->name;
+			$class      = is_object( $callable ) ? $callable : $reflection->name;
 			$subcommand = self::create_subcommand( $container, false, array( $class, $method->name ), $method );
 
 			$subcommand_name = $subcommand->get_name();
@@ -161,6 +162,17 @@ class CommandFactory {
 	 */
 	private static function is_good_method( $method ) {
 		return $method->isPublic() && ! $method->isStatic() && 0 !== strpos( $method->getName(), '__' );
+	}
+
+	/**
+	 * Check whether a method should be ignored.
+	 *
+	 * @param ReflectionMethod $method
+	 *
+	 * @return bool
+	 */
+	private static function should_ignore_method( $docparser ) {
+		return $docparser->has_tag( 'ignorecommand' );
 	}
 
 	/**

--- a/php/EE/DocParser.php
+++ b/php/EE/DocParser.php
@@ -92,6 +92,17 @@ class DocParser {
 	}
 
 	/**
+	 * Check if a given tag is present (e.g. "@alias" or "@subcommand")
+	 *
+	 * @param string $name Name for the tag, without '@'.
+	 *
+	 * @return bool
+	 */
+	public function has_tag( $name ) {
+		return preg_match( '|^@' . $name . '|m', $this->docComment, $matches );
+	}
+
+	/**
 	 * Get the command's synopsis.
 	 *
 	 * @return string

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -709,7 +709,7 @@ class Runner {
 		$args_search_two = array_search( '<site-name>', $synopsis );
 		$arg_position    = false !== $args_search_one ? $args_search_one : $args_search_two;
 
-		if ( false === $arg_position ) {
+		if ( false === $arg_position || 'create' === $function ) {
 			return;
 		}
 

--- a/php/bootstrap.php
+++ b/php/bootstrap.php
@@ -26,6 +26,7 @@ function get_bootstrap_steps() {
 		'EE\Bootstrap\LoadRequiredCommand',
 		'EE\Bootstrap\IncludePackageAutoloader',
 		'EE\Bootstrap\IncludeBundledAutoloader',
+		'EE\Bootstrap\LoadSiteUtilityFunctions',
 		'EE\Bootstrap\RegisterFrameworkCommands',
 		'EE\Bootstrap\IncludeFallbackAutoloader',
 		'EE\Bootstrap\RegisterDeferredCommands',

--- a/php/bootstrap.php
+++ b/php/bootstrap.php
@@ -30,6 +30,7 @@ function get_bootstrap_steps() {
 		'EE\Bootstrap\RegisterFrameworkCommands',
 		'EE\Bootstrap\IncludeFallbackAutoloader',
 		'EE\Bootstrap\RegisterDeferredCommands',
+		'EE\Bootstrap\RouteSiteCommands',
 		'EE\Bootstrap\LaunchRunner',
 	);
 }

--- a/php/class-ee-db.php
+++ b/php/class-ee-db.php
@@ -125,6 +125,8 @@ class EE_DB {
 	/**
 	 * @param array $columns
 	 * @param array $where
+	 * @param string $table_name
+	 * @param int|null $limit
 	 * Select data from the database.
 	 *
 	 * @return array|bool
@@ -167,6 +169,10 @@ class EE_DB {
 		}
 		if ( empty( $select_data ) ) {
 			return false;
+		}
+
+		if ( 1 === $limit ) {
+			return $select_data[0];
 		}
 
 		return $select_data;
@@ -295,9 +301,9 @@ class EE_DB {
 			self::init_db();
 		}
 
-		$site = self::select( array( 'site_type' ), array( 'sitename' => $site_name ) );
+		$site = self::select( [ 'site_type' ], [ 'sitename' => $site_name ], 'sites', 1 );
 
-		return $site[0]['site_type'];
+		return $site['site_type'];
 	}
 
 	/**

--- a/php/class-ee-db.php
+++ b/php/class-ee-db.php
@@ -38,6 +38,7 @@ class EE_DB {
 			sitename VARCHAR,
 			site_type VARCHAR,
 			site_title VARCHAR,
+			site_command VARCHAR,
 			proxy_type VARCHAR,
 			cache_type VARCHAR,
 			site_path VARCHAR,
@@ -279,6 +280,24 @@ class EE_DB {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get site type.
+	 *
+	 * @param String $site_name Name of the site.
+	 *
+	 * @return string type of site.
+	 */
+	public static function get_site_command( $site_name ) {
+
+		if ( empty ( self::$db ) ) {
+			self::init_db();
+		}
+
+		$site = self::select( array( 'site_type' ), array( 'sitename' => $site_name ) );
+
+		return $site[0]['site_type'];
 	}
 
 	/**

--- a/php/class-ee-site-letsencrypt.php
+++ b/php/class-ee-site-letsencrypt.php
@@ -1,0 +1,537 @@
+<?php
+
+use AcmePhp\Cli\Repository\Repository;
+use AcmePhp\Cli\Serializer\PemEncoder;
+use AcmePhp\Cli\Serializer\PemNormalizer;
+use AcmePhp\Core\AcmeClient;
+use AcmePhp\Core\Challenge\ChainValidator;
+use AcmePhp\Core\Challenge\WaitingValidator;
+use AcmePhp\Core\Challenge\Http\SimpleHttpSolver;
+use AcmePhp\Core\Challenge\Http\HttpValidator;
+use AcmePhp\Core\Challenge\Dns\SimpleDnsSolver;
+use AcmePhp\Core\Challenge\Dns\DnsValidator;
+use AcmePhp\Core\Exception\Protocol\ChallengeNotSupportedException;
+use AcmePhp\Core\Http\SecureHttpClient;
+use AcmePhp\Core\Http\Base64SafeEncoder;
+use AcmePhp\Core\Http\ServerErrorHandler;
+use AcmePhp\Ssl\Certificate;
+use AcmePhp\Ssl\CertificateRequest;
+use AcmePhp\Ssl\CertificateResponse;
+use AcmePhp\Ssl\DistinguishedName;
+use AcmePhp\Ssl\Parser\KeyParser;
+use AcmePhp\Ssl\Parser\CertificateParser;
+use AcmePhp\Ssl\Generator\KeyPairGenerator;
+use AcmePhp\Ssl\Signer\CertificateRequestSigner;
+use AcmePhp\Ssl\Signer\DataSigner;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Adapter\NullAdapter;
+use GuzzleHttp\Client;
+
+
+class Site_Letsencrypt {
+
+	private $accountKeyPair;
+	private $httpClient;
+	private $base64SafeEncoder;
+	private $keyParser;
+	private $dataSigner;
+	private $serverErrorHandler;
+	private $serializer;
+	private $master;
+	private $backup;
+	private $client;
+	private $repository;
+	private $conf_dir;
+
+	function __construct() {
+		$this->conf_dir = EE_CONF_ROOT . '/acme-conf';
+		$this->setRepository();
+		$this->setAcmeClient();
+	}
+
+	private function setAcmeClient() {
+
+		if ( ! $this->repository->hasAccountKeyPair() ) {
+			EE::debug( 'No account key pair was found, generating one.' );
+			EE::debug( 'Generating a key pair' );
+
+			$keygen         = new KeyPairGenerator();
+			$accountKeyPair = $keygen->generateKeyPair();
+			EE::debug( 'Key pair generated, storing' );
+			$this->repository->storeAccountKeyPair( $accountKeyPair );
+		} else {
+			EE::debug( 'Loading account keypair' );
+			$accountKeyPair = $this->repository->loadAccountKeyPair();
+		}
+
+		$this->accountKeyPair ?? $this->accountKeyPair = $accountKeyPair;
+
+		$secureHttpClient = $this->getSecureHttpClient();
+		$csrSigner        = new CertificateRequestSigner();
+
+		$this->client = new AcmeClient( $secureHttpClient, 'https://acme-v02.api.letsencrypt.org/directory', $csrSigner );
+
+	}
+
+	private function setRepository( $enable_backup = false ) {
+		$this->serializer ?? $this->serializer = new Serializer(
+			[ new PemNormalizer(), new GetSetMethodNormalizer() ],
+			[ new PemEncoder(), new JsonEncoder() ]
+		);
+		$this->master ?? $this->master = new Filesystem( new Local( $this->conf_dir ) );
+		$this->backup ?? $this->backup = new Filesystem( new NullAdapter() );
+
+		$this->repository = new Repository( $this->serializer, $this->master, $this->backup, $enable_backup );
+	}
+
+	private function getSecureHttpClient() {
+		$this->httpClient ?? $this->httpClient = new Client();
+		$this->base64SafeEncoder ?? $this->base64SafeEncoder = new Base64SafeEncoder();
+		$this->keyParser ?? $this->keyParser = new KeyParser();
+		$this->dataSigner ?? $this->dataSigner = new DataSigner();
+		$this->serverErrorHandler ?? $this->serverErrorHandler = new ServerErrorHandler();
+
+		return new SecureHttpClient(
+			$this->accountKeyPair,
+			$this->httpClient,
+			$this->base64SafeEncoder,
+			$this->keyParser,
+			$this->dataSigner,
+			$this->serverErrorHandler
+		);
+	}
+
+
+	public function register( $email ) {
+		try {
+			$this->client->registerAccount( null, $email );
+		}
+		catch ( Exception $e ) {
+			EE::warning( $e->getMessage() );
+			EE::warning( 'It seems you\'re in local environment or there is some issue with network, please check logs. Skipping letsencrypt.' );
+
+			return false;
+		}
+		EE::debug( "Account with email id: $email registered successfully!" );
+		return true;
+	}
+
+	public function authorize( Array $domains, $site_root, $wildcard = false ) {
+		$solver     = $wildcard ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleHttpSolver();
+		$solverName = $wildcard ? 'dns-01' : 'http-01';
+		try {
+			$order = $this->client->requestOrder( $domains );
+		}
+		catch ( Exception $e ) {
+			EE::warning( $e->getMessage() );
+			EE::warning( 'It seems you\'re in local environment or using non-public domain, please check logs. Skipping letsencrypt.' );
+
+			return false;
+		}
+
+		$authorizationChallengesToSolve = [];
+		foreach ( $order->getAuthorizationsChallenges() as $domainKey => $authorizationChallenges ) {
+			$authorizationChallenge = null;
+			foreach ( $authorizationChallenges as $candidate ) {
+				if ( $solver->supports( $candidate ) ) {
+					$authorizationChallenge = $candidate;
+					EE::debug( 'Authorization challenge supported by solver. Solver: ' . $solverName . ' Challenge: ' . $candidate->getType() );
+					break;
+				}
+				// Should not get here as we are handling it.
+				EE::debug( 'Authorization challenge not supported by solver. Solver: ' . $solverName . ' Challenge: ' . $candidate->getType() );
+			}
+			if ( null === $authorizationChallenge ) {
+				throw new ChallengeNotSupportedException();
+			}
+			EE::debug( 'Storing authorization challenge. Domain: ' . $domainKey . ' Challenge: ' . print_r( $authorizationChallenge->toArray(), true ) );
+
+			$this->repository->storeDomainAuthorizationChallenge( $domainKey, $authorizationChallenge );
+			$authorizationChallengesToSolve[] = $authorizationChallenge;
+		}
+
+		/** @var AuthorizationChallenge $authorizationChallenge */
+		foreach ( $authorizationChallengesToSolve as $authorizationChallenge ) {
+			EE::debug( 'Solving authorization challenge: Domain: ' . $authorizationChallenge->getDomain() . ' Challenge: ' . print_r( $authorizationChallenge->toArray(), true ) );
+			$solver->solve( $authorizationChallenge );
+		}
+
+		$this->repository->storeCertificateOrder( $domains, $order );
+
+		if ( ! $wildcard ) {
+			$token   = $authorizationChallenge->toArray()['token'];
+			$payload = $authorizationChallenge->toArray()['payload'];
+			EE::launch( "mkdir -p $site_root/app/src/.well-known/acme-challenge/" );
+			EE::debug( "Creating challange file $site_root/app/src/.well-known/acme-challenge/$token" );
+			file_put_contents( "$site_root/app/src/.well-known/acme-challenge/$token", $payload );
+			EE::launch( "chown www-data: $site_root/app/src/.well-known/acme-challenge/$token" );
+		}
+		return true;
+	}
+
+	public function check( Array $domains, $wildcard = false ) {
+		EE::debug( 'Starting check with solver ' . $wildcard ? 'dns' : 'http' );
+		$solver    = $wildcard ? new SimpleDnsSolver( null, new ConsoleOutput() ) : new SimpleHttpSolver();
+		$validator = new ChainValidator(
+			[
+				new WaitingValidator( new HttpValidator() ),
+				new WaitingValidator( new DnsValidator() )
+			]
+		);
+
+		$order = null;
+		if ( $this->repository->hasCertificateOrder( $domains ) ) {
+			$order = $this->repository->loadCertificateOrder( $domains );
+			EE::debug( sprintf( 'Loading the authorization token for domains %s ...', implode( ', ', $domains ) ) );
+		}
+
+		$authorizationChallengeToCleanup = [];
+		foreach ( $domains as $domain ) {
+			if ( $order ) {
+				$authorizationChallenge  = null;
+				$authorizationChallenges = $order->getAuthorizationChallenges( $domain );
+				foreach ( $authorizationChallenges as $challenge ) {
+					if ( $solver->supports( $challenge ) ) {
+						$authorizationChallenge = $challenge;
+						break;
+					}
+				}
+				if ( null === $authorizationChallenge ) {
+					throw new ChallengeNotSupportedException();
+				}
+			} else {
+				if ( ! $this->repository->hasDomainAuthorizationChallenge( $domain ) ) {
+					EE::error( "Domain: $domain not yet authorized/has not been started of with EasyEngine letsencrypt site creation." );
+				}
+				$authorizationChallenge = $this->repository->loadDomainAuthorizationChallenge( $domain );
+				if ( ! $solver->supports( $authorizationChallenge ) ) {
+					throw new ChallengeNotSupportedException();
+				}
+			}
+			EE::debug( 'Challenge loaded.' );
+
+			$authorizationChallenge = $this->client->reloadAuthorization( $authorizationChallenge );
+			if ( ! $authorizationChallenge->isValid() ) {
+				EE::debug( sprintf( 'Testing the challenge for domain %s', $domain ) );
+				if ( ! $validator->isValid( $authorizationChallenge ) ) {
+					EE::warning( sprintf( 'Can not valid challenge for domain %s', $domain ) );
+				}
+
+				EE::debug( sprintf( 'Requesting authorization check for domain %s', $domain ) );
+				try {
+					$this->client->challengeAuthorization( $authorizationChallenge );
+				}
+				catch ( Exception $e ) {
+					EE::debug( $e->getMessage() );
+					EE::warning( 'Challange Authorization failed. Check logs and check if your domain is pointed correctly to this server.' );
+					$site_name = isset( $domains[1] ) ? $domains[1] : $domains[0];
+					EE::log( "Re-run `ee site le $site_name` after fixing the issue." );
+
+					return false;
+				}
+				$authorizationChallengeToCleanup[] = $authorizationChallenge;
+			}
+		}
+
+		EE::log( 'The authorization check was successful!' );
+
+		if ( $solver instanceof MultipleChallengesSolverInterface ) {
+			$solver->cleanupAll( $authorizationChallengeToCleanup );
+		} else {
+			/** @var AuthorizationChallenge $authorizationChallenge */
+			foreach ( $authorizationChallengeToCleanup as $authorizationChallenge ) {
+				$solver->cleanup( $authorizationChallenge );
+			}
+		}
+		return true;
+	}
+
+	public function request( $domain, $altNames = [], $email, $force=false ) {
+		$alternativeNames = array_unique( $altNames );
+		sort( $alternativeNames );
+
+		// Certificate renewal
+		if ( $this->hasValidCertificate( $domain, $alternativeNames ) ) {
+			EE::debug( "Certificate found for $domain, executing renewal" );
+
+			return $this->executeRenewal( $domain, $alternativeNames, $force );
+		}
+
+		EE::debug( "No certificate found, executing first request for $domain" );
+
+		// Certificate first request
+		return $this->executeFirstRequest( $domain, $alternativeNames, $email );
+	}
+
+	/**
+	 * Request a first certificate for the given domain.
+	 *
+	 * @param string $domain
+	 * @param array  $alternativeNames
+	 */
+	private function executeFirstRequest( $domain, array $alternativeNames, $email ) {
+		EE::log( 'Executing first request.' );
+
+		// Generate domain key pair
+		$keygen        = new KeyPairGenerator();
+		$domainKeyPair = $keygen->generateKeyPair();
+		$this->repository->storeDomainKeyPair( $domain, $domainKeyPair );
+
+		EE::debug( "$domain Domain key pair generated and stored" );
+
+		$distinguishedName = $this->getOrCreateDistinguishedName( $domain, $alternativeNames, $email );
+		// TODO: ask them ;)
+		EE::debug( 'Distinguished name informations have been stored locally for this domain (they won\'t be asked on renewal).' );
+
+		// Order
+		$domains = array_merge( [ $domain ], $alternativeNames );
+		EE::debug( sprintf( 'Loading the order related to the domains %s .', implode( ', ', $domains ) ) );
+		if ( ! $this->repository->hasCertificateOrder( $domains ) ) {
+			EE::error( "$domain has not yet been authorized." );
+		}
+		$order = $this->repository->loadCertificateOrder( $domains );
+
+		// Request
+		EE::log( sprintf( 'Requesting first certificate for domain %s.', $domain ) );
+		$csr      = new CertificateRequest( $distinguishedName, $domainKeyPair );
+		$response = $this->client->finalizeOrder( $order, $csr );
+		EE::log( 'Certificate received' );
+
+		// Store
+		$this->repository->storeDomainCertificate( $domain, $response->getCertificate() );
+		EE::log( 'Certificate stored' );
+
+		// Post-generate actions
+		$this->moveCertsToNginxProxy( $response );
+	}
+
+	private function moveCertsToNginxProxy( CertificateResponse $response ) {
+		$domain      = $response->getCertificateRequest()->getDistinguishedName()->getCommonName();
+		$privateKey  = $response->getCertificateRequest()->getKeyPair()->getPrivateKey();
+		$certificate = $response->getCertificate();
+
+		// To handle wildcard certs
+		$domain = ltrim( $domain, '*.' );
+
+		file_put_contents( EE_CONF_ROOT . '/nginx/certs/' . $domain . '.key', $privateKey->getPEM() );
+
+		// Issuer chain
+		$issuerChain = array_map(
+			function ( Certificate $certificate ) {
+				return $certificate->getPEM();
+			}, $certificate->getIssuerChain()
+		);
+
+		// Full chain
+		$fullChainPem = $certificate->getPEM() . "\n" . implode( "\n", $issuerChain );
+
+		file_put_contents( EE_CONF_ROOT . '/nginx/certs/' . $domain . '.crt', $fullChainPem );
+	}
+
+	/**
+	 * Renew a given domain certificate.
+	 *
+	 * @param string $domain
+	 * @param array  $alternativeNames
+	 * @param bool   $force
+	 */
+	private function executeRenewal( $domain, array $alternativeNames, $force = false ) {
+		try {
+			// Check expiration date to avoid too much renewal
+			EE::log( "Loading current certificate for $domain" );
+
+			$certificate = $this->repository->loadDomainCertificate( $domain );
+
+			if ( ! $force ) {
+				$certificateParser = new CertificateParser();
+				$parsedCertificate = $certificateParser->parse( $certificate );
+
+				if ( $parsedCertificate->getValidTo()->format( 'U' ) - time() >= 604800 ) {
+
+					EE::log(
+						sprintf(
+							'Current certificate is valid until %s, renewal is not necessary.',
+							$parsedCertificate->getValidTo()->format( 'Y-m-d H:i:s' )
+						)
+					);
+
+					return;
+				}
+
+				EE::log(
+					sprintf(
+						'Current certificate will expire in less than a week (%s), renewal is required.',
+						$parsedCertificate->getValidTo()->format( 'Y-m-d H:i:s' )
+					)
+				);
+			} else {
+				EE::log( 'Forced renewal.' );
+			}
+
+			// Key pair
+			EE::debug( 'Loading domain key pair...' );
+			$domainKeyPair = $this->repository->loadDomainKeyPair( $domain );
+
+			// Distinguished name
+			EE::debug( 'Loading domain distinguished name...' );
+			$distinguishedName = $this->getOrCreateDistinguishedName( $domain, $alternativeNames );
+
+			// Order
+			$domains = array_merge( [ $domain ], $alternativeNames );
+			EE::debug( sprintf( 'Loading the order related to the domains %s.', implode( ', ', $domains ) ) );
+			if ( ! $this->repository->hasCertificateOrder( $domains ) ) {
+				EE::error( "$domain has not yet been authorized." );
+			}
+			$order = $this->repository->loadCertificateOrder( $domains );
+
+			// Renewal
+			EE::log( sprintf( 'Renewing certificate for domain %s.', $domain ) );
+			$csr      = new CertificateRequest( $distinguishedName, $domainKeyPair );
+			$response = $this->client->finalizeOrder( $order, $csr );
+			EE::log( 'Certificate received' );
+
+			$this->repository->storeDomainCertificate( $domain, $response->getCertificate() );
+			$this->log( 'Certificate stored' );
+
+			// Post-generate actions
+			$this->moveCertsToNginxProxy( $response );
+			EE::log( 'Certificate renewed successfully!' );
+
+		}
+		catch ( \Exception $e ) {
+			EE::warning( 'A critical error occured during certificate renewal' );
+			EE::debug( print_r( $e, true ) );
+
+			throw $e;
+		}
+		catch ( \Throwable $e ) {
+			EE::warning( 'A critical error occured during certificate renewal' );
+			EE::debug( print_r( $e, true ) );
+
+			throw $e;
+		}
+	}
+
+	private function hasValidCertificate( $domain, array $alternativeNames ) {
+		if ( ! $this->repository->hasDomainCertificate( $domain ) ) {
+			return false;
+		}
+
+		if ( ! $this->repository->hasDomainKeyPair( $domain ) ) {
+			return false;
+		}
+
+		if ( ! $this->repository->hasDomainDistinguishedName( $domain ) ) {
+			return false;
+		}
+
+		if ( $this->repository->loadDomainDistinguishedName( $domain )->getSubjectAlternativeNames() !== $alternativeNames ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieve the stored distinguishedName or create a new one if needed.
+	 *
+	 * @param string $domain
+	 * @param array  $alternativeNames
+	 *
+	 * @return DistinguishedName
+	 */
+	private function getOrCreateDistinguishedName( $domain, array $alternativeNames, $email ) {
+		if ( $this->repository->hasDomainDistinguishedName( $domain ) ) {
+			$original = $this->repository->loadDomainDistinguishedName( $domain );
+
+			$distinguishedName = new DistinguishedName(
+				$domain,
+				$original->getCountryName(),
+				$original->getStateOrProvinceName(),
+				$original->getLocalityName(),
+				$original->getOrganizationName(),
+				$original->getOrganizationalUnitName(),
+				$original->getEmailAddress(),
+				$alternativeNames
+			);
+		} else {
+			// Ask DistinguishedName
+			$distinguishedName = new DistinguishedName(
+				$domain,
+				// TODO: Ask and fill these values properly
+				'US',
+				'CA',
+				'Mountain View',
+				'Let\'s Encrypt',
+				'Let\'s Encrypt Authority X3',
+				$email,
+				$alternativeNames
+			);
+
+		}
+
+		$this->repository->storeDomainDistinguishedName( $domain, $distinguishedName );
+
+		return $distinguishedName;
+	}
+
+
+	public function status() {
+		$this->master ?? $this->master = new Filesystem( new Local( $this->conf_dir ) );
+
+		$certificateParser = new CertificateParser();
+
+		$table = new Table( $output );
+		$table->setHeaders( [ 'Domain', 'Issuer', 'Valid from', 'Valid to', 'Needs renewal?' ] );
+
+		$directories = $this->master->listContents( 'certs' );
+
+		foreach ( $directories as $directory ) {
+			if ( 'dir' !== $directory['type'] ) {
+				continue;
+			}
+
+			$parsedCertificate = $certificateParser->parse( $this->repository->loadDomainCertificate( $directory['basename'] ) );
+			if ( ! $input->getOption( 'all' ) && $parsedCertificate->isExpired() ) {
+				continue;
+			}
+			$domainString = $parsedCertificate->getSubject();
+
+			$alternativeNames = array_diff( $parsedCertificate->getSubjectAlternativeNames(), [ $parsedCertificate->getSubject() ] );
+			if ( count( $alternativeNames ) ) {
+				sort( $alternativeNames );
+				$last = array_pop( $alternativeNames );
+				foreach ( $alternativeNames as $alternativeName ) {
+					$domainString .= "\n ├── " . $alternativeName;
+				}
+				$domainString .= "\n └── " . $last;
+			}
+
+			$table->addRow(
+				[
+					$domainString,
+					$parsedCertificate->getIssuer(),
+					$parsedCertificate->getValidFrom()->format( 'Y-m-d H:i:s' ),
+					$parsedCertificate->getValidTo()->format( 'Y-m-d H:i:s' ),
+					( $parsedCertificate->getValidTo()->format( 'U' ) - time() < 604800 ) ? '<comment>Yes</comment>' : 'No',
+				]
+			);
+		}
+
+		$table->render();
+	}
+
+	public function cleanup(  $site_root ) {
+		$challange_dir = "$site_root/app/src/.well-known";
+		if ( file_exists( "$site_root/app/src/.well-known" ) ) {
+			EE::debug( 'Cleaning up webroot files.' );
+			EE\Utils\delete_dir( $challange_dir );
+		}
+	}
+}

--- a/php/class-ee-site-shutdown-handler.php
+++ b/php/class-ee-site-shutdown-handler.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class Shutdown_Handler
+ */
+class Shutdown_Handler {
+
+	/**
+	 * Handle fatal errors. This function was created as the register_shutdown_function requires the callable function to be public and any public function inside site-command would be callable directly through command-line.
+	 *
+	 * @param array $site_command having Site_Command object.
+	 */
+	public function cleanup( $site_command ) {
+		$reflector = new ReflectionObject( $site_command[0] );
+		$method    = $reflector->getMethod( 'shutDownFunction' );
+		$method->setAccessible( true );
+		$method->invoke( $site_command[0] );
+	}
+}

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Base class for Site command
+ *
+ * @package ee
+ */
+abstract class EE_Site_Command {
+
+	public function __construct() {}
+
+	public function _list( $args, $assoc_args ) {}
+
+	public function delete( $args, $assoc_args ) {}
+
+	public function create( $args, $assoc_args ) {}
+
+	public function up( $args, $assoc_args ) {}
+
+	public function down( $args, $assoc_args ) {}
+
+}
+

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -85,7 +85,101 @@ abstract class EE_Site_Command {
 	}
 
 
-	public function delete( $args, $assoc_args ) {}
+	/**
+	 * Deletes a website.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <site-name>
+	 * : Name of website to be deleted.
+	 *
+	 * [--yes]
+	 * : Do not prompt for confirmation.
+	 */
+	public function delete( $args, $assoc_args ) {
+		\EE\Utils\delem_log( 'site delete start' );
+		$this->populate_site_info( $args );
+		EE::confirm( "Are you sure you want to delete $this->site_name?", $assoc_args );
+		$this->delete_site( 5, $this->site_name, $this->site_root );
+		\EE\Utils\delem_log( 'site delete end' );
+	}
+
+	/**
+	 * Function to delete the given site.
+	 *
+	 * @param int $level
+	 *  Level of deletion.
+	 *  Level - 0: No need of clean-up.
+	 *  Level - 1: Clean-up only the site-root.
+	 *  Level - 2: Try to remove network. The network may or may not have been created.
+	 *  Level - 3: Disconnect & remove network and try to remove containers. The containers may not have been created.
+	 *  Level - 4: Remove containers.
+	 *  Level - 5: Remove db entry.
+	 *
+	 * @ignorecommand
+	 */
+	public function delete_site( $level, $site_name, $site_root ) {
+		$this->fs   = new Filesystem();
+		$proxy_type = EE_PROXY_TYPE;
+		if ( $level >= 3 ) {
+			if ( EE::docker()::docker_compose_down( $site_root ) ) {
+				EE::log( "[$site_name] Docker Containers removed." );
+			} else {
+				\EE\Utils\default_launch( "docker rm -f $(docker ps -q -f=label=created_by=EasyEngine -f=label=site_name=$site_name)" );
+				if ( $level > 3 ) {
+					EE::warning( 'Error in removing docker containers.' );
+				}
+			}
+
+			EE::docker()::disconnect_site_network_from( $site_name, $proxy_type );
+		}
+
+		if ( $level >= 2 ) {
+			if ( EE::docker()::rm_network( $site_name ) ) {
+				EE::log( "[$site_name] Docker container removed from network $proxy_type." );
+			} else {
+				if ( $level > 2 ) {
+					EE::warning( "Error in removing Docker container from network $proxy_type" );
+				}
+			}
+		}
+
+		if ( $this->fs->exists( $site_root ) ) {
+			try {
+				$this->fs->remove( $site_root );
+			}
+			catch ( Exception $e ) {
+				EE::debug( $e );
+				EE::error( 'Could not remove site root. Please check if you have sufficient rights.' );
+			}
+			EE::log( "[$site_name] site root removed." );
+		}
+
+		if ( $level > 4 ) {
+			if ( $this->le ) {
+				EE::log( 'Removing ssl certs.' );
+				$crt_file   = EE_CONF_ROOT . "/nginx/certs/$site_name.crt";
+				$key_file   = EE_CONF_ROOT . "/nginx/certs/$site_name.key";
+				$conf_certs = EE_CONF_ROOT . "/acme-conf/certs/$site_name";
+				$conf_var   = EE_CONF_ROOT . "/acme-conf/var/$site_name";
+
+				$cert_files = [ $conf_certs, $conf_var, $crt_file, $key_file ];
+				try {
+					$this->fs->remove( $cert_files );
+				}
+				catch ( Exception $e ) {
+					EE::warning( $e );
+				}
+
+			}
+			if ( EE::db()::delete( array( 'sitename' => $site_name ) ) ) {
+				EE::log( 'Removing database entry.' );
+			} else {
+				EE::error( 'Could not remove the database entry' );
+			}
+		}
+		EE::log( "Site $site_name deleted." );
+	}
 
 	public function create( $args, $assoc_args ) {}
 

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -17,7 +17,73 @@ abstract class EE_Site_Command {
 
 	public function __construct() {}
 
-	public function _list( $args, $assoc_args ) {}
+	/**
+	 * Lists the created websites.
+	 * abstract list
+	 *
+	 * [--enabled]
+	 * : List only enabled sites.
+	 *
+	 * [--disabled]
+	 * : List only disabled sites.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - yaml
+	 *   - json
+	 *   - count
+	 *   - text
+	 * ---
+	 *
+	 * @subcommand list
+	 */
+	public function _list( $args, $assoc_args ) {
+		\EE\Utils\delem_log( 'site list start' );
+		$format   = \EE\Utils\get_flag_value( $assoc_args, 'format' );
+		$enabled  = \EE\Utils\get_flag_value( $assoc_args, 'enabled' );
+		$disabled = \EE\Utils\get_flag_value( $assoc_args, 'disabled' );
+
+		$where = array();
+
+		if ( $enabled && ! $disabled ) {
+			$where['is_enabled'] = 1;
+		} elseif ( $disabled && ! $enabled ) {
+			$where['is_enabled'] = 0;
+		}
+
+		$sites = EE::db()::select( array( 'sitename', 'is_enabled' ), $where );
+
+		if ( ! $sites ) {
+			EE::error( 'No sites found!' );
+		}
+
+		if ( 'text' === $format ) {
+			foreach ( $sites as $site ) {
+				EE::log( $site['sitename'] );
+			}
+		} else {
+			$result = array_map(
+				function ( $site ) {
+					$site['site']   = $site['sitename'];
+					$site['status'] = $site['is_enabled'] ? 'enabled' : 'disabled';
+
+					return $site;
+				}, $sites
+			);
+
+			$formatter = new \EE\Formatter( $assoc_args, [ 'site', 'status' ] );
+
+			$formatter->display_items( $result );
+		}
+
+		\EE\Utils\delem_log( 'site list end' );
+	}
+
 
 	public function delete( $args, $assoc_args ) {}
 

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -425,6 +425,6 @@ abstract class EE_Site_Command {
 		}
 	}
 
-	public function create( $args, $assoc_args ) {}
+	abstract public function create( $args, $assoc_args );
 
 }

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -375,6 +375,26 @@ abstract class EE_Site_Command {
 		EE::launch( 'docker exec ee-nginx-proxy sh -c "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload"' );
 	}
 
+	/**
+	 * Populate basic site info from db.
+	 */
+	private function populate_site_info( $args ) {
+
+		$this->site_name = \EE\Utils\remove_trailing_slash( $args[0] );
+
+		if ( EE::db()::site_in_db( $this->site_name ) ) {
+
+			$db_select = EE::db()::select( [], array( 'sitename' => $this->site_name ) );
+
+			$this->site_type = $db_select[0]['site_type'];
+			$this->site_root = $db_select[0]['site_path'];
+			$this->le        = $db_select[0]['is_ssl'];
+
+		} else {
+			EE::error( "Site $this->site_name does not exist." );
+		}
+	}
+
 	public function create( $args, $assoc_args ) {}
 
 }

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -188,11 +188,18 @@ abstract class EE_Site_Command {
 	 *
 	 * [<site-name>]
 	 * : Name of website to be enabled.
+	 *
+	 * [--force]
+	 * : Force execution of site up.
 	 */
 	public function up( $args, $assoc_args ) {
 		\EE\Utils\delem_log( 'site enable start' );
-		$args = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+		$force = \EE\Utils\get_flag_value( $assoc_args, 'force' );
+		$args  = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$this->populate_site_info( $args );
+		if ( EE::db()::site_enabled( $this->site_name ) && ! $force ) {
+			EE::error( "$this->site_name is already enabled!" );
+		}
 		EE::log( "Enabling site $this->site_name." );
 		if ( EE::docker()::docker_compose_up( $this->site_root ) ) {
 			EE::db()::update( [ 'is_enabled' => '1' ], [ 'sitename' => $this->site_name ] );

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -386,7 +386,7 @@ abstract class EE_Site_Command {
 
 		if ( EE::db()::site_in_db( $this->site_name ) ) {
 
-			$db_select = $this->db::select( [], [ 'sitename' => $this->site_name ], 'sites', 1 );
+			$db_select = EE::db()::select( [], [ 'sitename' => $this->site_name ], 'sites', 1 );
 
 			$this->site_type = $db_select['site_type'];
 			$this->site_root = $db_select['site_path'];

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -181,11 +181,51 @@ abstract class EE_Site_Command {
 		EE::log( "Site $site_name deleted." );
 	}
 
+	/**
+	 * Enables a website. It will start the docker containers of the website if they are stopped.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<site-name>]
+	 * : Name of website to be enabled.
+	 */
+	public function up( $args, $assoc_args ) {
+		\EE\Utils\delem_log( 'site enable start' );
+		$args = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+		$this->populate_site_info( $args );
+		EE::log( "Enabling site $this->site_name." );
+		if ( EE::docker()::docker_compose_up( $this->site_root ) ) {
+			EE::db()::update( [ 'is_enabled' => '1' ], [ 'sitename' => $this->site_name ] );
+			EE::success( "Site $this->site_name enabled." );
+		} else {
+			EE::error( "There was error in enabling $this->site_name. Please check logs." );
+		}
+		\EE\Utils\delem_log( 'site enable end' );
+	}
+
+	/**
+	 * Disables a website. It will stop and remove the docker containers of the website if they are running.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<site-name>]
+	 * : Name of website to be disabled.
+	 */
+	public function down( $args, $assoc_args ) {
+		\EE\Utils\delem_log( 'site disable start' );
+		$args = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+		$this->populate_site_info( $args );
+		EE::log( "Disabling site $this->site_name." );
+		if ( EE::docker()::docker_compose_down( $this->site_root ) ) {
+			EE::db()::update( [ 'is_enabled' => '0' ], [ 'sitename' => $this->site_name ] );
+			EE::success( "Site $this->site_name disabled." );
+		} else {
+			EE::error( "There was error in disabling $this->site_name. Please check logs." );
+		}
+		\EE\Utils\delem_log( 'site disable end' );
+	}
+
 	public function create( $args, $assoc_args ) {}
-
-	public function up( $args, $assoc_args ) {}
-
-	public function down( $args, $assoc_args ) {}
 
 }
 

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -225,7 +225,7 @@ abstract class EE_Site_Command {
 		\EE\Utils\delem_log( 'site disable end' );
 	}
 
-		/**
+	/**
 	 * Restarts containers associated with site.
 	 * When no service(--nginx etc.) is specified, all site containers will be restarted.
 	 *
@@ -238,7 +238,7 @@ abstract class EE_Site_Command {
 	 * [--nginx]
 	 * : Restart nginx container of site.
 	 */
-	public function restart( $args, $assoc_args ) {
+	public function restart( $args, $assoc_args, $whitelisted_containers = [] ) {
 		\EE\Utils\delem_log( 'site restart start' );
 		$args                 = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$all                  = \EE\Utils\get_flag_value( $assoc_args, 'all' );
@@ -249,7 +249,7 @@ abstract class EE_Site_Command {
 		chdir( $this->site_root );
 
 		if ( $all || $no_service_specified ) {
-			$containers = [ 'nginx' ];
+			$containers = $whitelisted_containers;
 		} else {
 			$containers = array_keys( $assoc_args );
 		}
@@ -274,7 +274,7 @@ abstract class EE_Site_Command {
 	 * : Reload nginx service in container.
 	 *
 	 */
-	public function reload( $args, $assoc_args ) {
+	public function reload( $args, $assoc_args, $whitelisted_containers = [] ) {
 		\EE\Utils\delem_log( 'site reload start' );
 		$args                 = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$all                  = \EE\Utils\get_flag_value( $assoc_args, 'all' );
@@ -285,7 +285,7 @@ abstract class EE_Site_Command {
 		chdir( $this->site_root );
 
 		if ( $all || $no_service_specified ) {
-			$this->reload_services( [ 'nginx' ] );
+			$this->reload_services( $whitelisted_containers );
 		} else {
 			$this->reload_services( array_keys( $assoc_args ) );
 		}
@@ -378,4 +378,3 @@ abstract class EE_Site_Command {
 	public function create( $args, $assoc_args ) {}
 
 }
-

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -115,10 +115,8 @@ abstract class EE_Site_Command {
 	 *  Level - 3: Disconnect & remove network and try to remove containers. The containers may not have been created.
 	 *  Level - 4: Remove containers.
 	 *  Level - 5: Remove db entry.
-	 *
-	 * @ignorecommand
 	 */
-	public function delete_site( $level, $site_name, $site_root ) {
+	protected function delete_site( $level, $site_name, $site_root ) {
 		$this->fs   = new Filesystem();
 		$proxy_type = EE_PROXY_TYPE;
 		if ( $level >= 3 ) {
@@ -317,10 +315,8 @@ abstract class EE_Site_Command {
 	 * @param string $site_name Name of the site for ssl.
 	 * @param string $site_root Webroot of the site.
 	 * @param bool   $wildcard  SSL with wildcard or not.
-	 *
-	 * @ignorecommand
 	 */
-	public function init_le( $site_name, $site_root, $wildcard = false ) {
+	protected function init_le( $site_name, $site_root, $wildcard = false ) {
 		$this->site_name = $site_name;
 		$this->site_root = $site_root;
 		$client          = new Site_Letsencrypt();

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -1,11 +1,19 @@
 <?php
 
+use \Symfony\Component\Filesystem\Filesystem;
+
 /**
  * Base class for Site command
  *
  * @package ee
  */
 abstract class EE_Site_Command {
+	private $fs;
+	private $le;
+	private $le_mail;
+	private $site_name;
+	private $site_root;
+	private $site_type;
 
 	public function __construct() {}
 

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -390,11 +390,11 @@ abstract class EE_Site_Command {
 
 		if ( EE::db()::site_in_db( $this->site_name ) ) {
 
-			$db_select = EE::db()::select( [], array( 'sitename' => $this->site_name ) );
+			$db_select = $this->db::select( [], [ 'sitename' => $this->site_name ], 'sites', 1 );
 
-			$this->site_type = $db_select[0]['site_type'];
-			$this->site_root = $db_select[0]['site_path'];
-			$this->le        = $db_select[0]['is_ssl'];
+			$this->site_type = $db_select['site_type'];
+			$this->site_root = $db_select['site_path'];
+			$this->le        = $db_select['is_ssl'];
 
 		} else {
 			EE::error( "Site $this->site_name does not exist." );

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -255,7 +255,7 @@ abstract class EE_Site_Command {
 		}
 
 		foreach ( $containers as $container ) {
-			EE\Siteutils\run_compose_command( 'restart', $container, null, 'all services' );
+			EE\Siteutils\run_compose_command( 'restart', $container );
 		}
 		\EE\Utils\delem_log( 'site restart stop' );
 	}
@@ -264,7 +264,7 @@ abstract class EE_Site_Command {
 	 * Reload services in containers without restarting container(s) associated with site.
 	 * When no service(--nginx etc.) is specified, all services will be reloaded.
 	 *
-	 * <site-name>
+	 * [<site-name>]
 	 * : Name of the site.
 	 *
 	 * [--all]

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -43,10 +43,11 @@ abstract class EE_Site_Command {
 	 * @subcommand list
 	 */
 	public function _list( $args, $assoc_args ) {
-		\EE\Utils\delem_log( 'site list start' );
-		$format   = \EE\Utils\get_flag_value( $assoc_args, 'format' );
-		$enabled  = \EE\Utils\get_flag_value( $assoc_args, 'enabled' );
-		$disabled = \EE\Utils\get_flag_value( $assoc_args, 'disabled' );
+
+		EE\Utils\delem_log( 'site list start' );
+		$format   = EE\Utils\get_flag_value( $assoc_args, 'format' );
+		$enabled  = EE\Utils\get_flag_value( $assoc_args, 'enabled' );
+		$disabled = EE\Utils\get_flag_value( $assoc_args, 'disabled' );
 
 		$where = array();
 
@@ -76,12 +77,12 @@ abstract class EE_Site_Command {
 				}, $sites
 			);
 
-			$formatter = new \EE\Formatter( $assoc_args, [ 'site', 'status' ] );
+			$formatter = new EE\Formatter( $assoc_args, [ 'site', 'status' ] );
 
 			$formatter->display_items( $result );
 		}
 
-		\EE\Utils\delem_log( 'site list end' );
+		EE\Utils\delem_log( 'site list end' );
 	}
 
 
@@ -97,11 +98,12 @@ abstract class EE_Site_Command {
 	 * : Do not prompt for confirmation.
 	 */
 	public function delete( $args, $assoc_args ) {
-		\EE\Utils\delem_log( 'site delete start' );
+
+		EE\Utils\delem_log( 'site delete start' );
 		$this->populate_site_info( $args );
 		EE::confirm( "Are you sure you want to delete $this->site_name?", $assoc_args );
 		$this->delete_site( 5, $this->site_name, $this->site_root );
-		\EE\Utils\delem_log( 'site delete end' );
+		EE\Utils\delem_log( 'site delete end' );
 	}
 
 	/**
@@ -117,13 +119,14 @@ abstract class EE_Site_Command {
 	 *  Level - 5: Remove db entry.
 	 */
 	protected function delete_site( $level, $site_name, $site_root ) {
+
 		$this->fs   = new Filesystem();
 		$proxy_type = EE_PROXY_TYPE;
 		if ( $level >= 3 ) {
 			if ( EE::docker()::docker_compose_down( $site_root ) ) {
 				EE::log( "[$site_name] Docker Containers removed." );
 			} else {
-				\EE\Utils\default_launch( "docker rm -f $(docker ps -q -f=label=created_by=EasyEngine -f=label=site_name=$site_name)" );
+				EE\Utils\default_launch( "docker rm -f $(docker ps -q -f=label=created_by=EasyEngine -f=label=site_name=$site_name)" );
 				if ( $level > 3 ) {
 					EE::warning( 'Error in removing docker containers.' );
 				}
@@ -145,8 +148,7 @@ abstract class EE_Site_Command {
 		if ( $this->fs->exists( $site_root ) ) {
 			try {
 				$this->fs->remove( $site_root );
-			}
-			catch ( Exception $e ) {
+			} catch ( Exception $e ) {
 				EE::debug( $e );
 				EE::error( 'Could not remove site root. Please check if you have sufficient rights.' );
 			}
@@ -164,8 +166,7 @@ abstract class EE_Site_Command {
 				$cert_files = [ $conf_certs, $conf_var, $crt_file, $key_file ];
 				try {
 					$this->fs->remove( $cert_files );
-				}
-				catch ( Exception $e ) {
+				} catch ( Exception $e ) {
 					EE::warning( $e );
 				}
 
@@ -191,9 +192,10 @@ abstract class EE_Site_Command {
 	 * : Force execution of site up.
 	 */
 	public function up( $args, $assoc_args ) {
-		\EE\Utils\delem_log( 'site enable start' );
-		$force = \EE\Utils\get_flag_value( $assoc_args, 'force' );
-		$args  = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+
+		EE\Utils\delem_log( 'site enable start' );
+		$force = EE\Utils\get_flag_value( $assoc_args, 'force' );
+		$args  = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$this->populate_site_info( $args );
 		if ( EE::db()::site_enabled( $this->site_name ) && ! $force ) {
 			EE::error( "$this->site_name is already enabled!" );
@@ -205,7 +207,7 @@ abstract class EE_Site_Command {
 		} else {
 			EE::error( "There was error in enabling $this->site_name. Please check logs." );
 		}
-		\EE\Utils\delem_log( 'site enable end' );
+		EE\Utils\delem_log( 'site enable end' );
 	}
 
 	/**
@@ -217,8 +219,9 @@ abstract class EE_Site_Command {
 	 * : Name of website to be disabled.
 	 */
 	public function down( $args, $assoc_args ) {
-		\EE\Utils\delem_log( 'site disable start' );
-		$args = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+
+		EE\Utils\delem_log( 'site disable start' );
+		$args = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$this->populate_site_info( $args );
 		EE::log( "Disabling site $this->site_name." );
 		if ( EE::docker()::docker_compose_down( $this->site_root ) ) {
@@ -227,7 +230,7 @@ abstract class EE_Site_Command {
 		} else {
 			EE::error( "There was error in disabling $this->site_name. Please check logs." );
 		}
-		\EE\Utils\delem_log( 'site disable end' );
+		EE\Utils\delem_log( 'site disable end' );
 	}
 
 	/**
@@ -244,9 +247,10 @@ abstract class EE_Site_Command {
 	 * : Restart nginx container of site.
 	 */
 	public function restart( $args, $assoc_args, $whitelisted_containers = [] ) {
-		\EE\Utils\delem_log( 'site restart start' );
-		$args                 = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
-		$all                  = \EE\Utils\get_flag_value( $assoc_args, 'all' );
+
+		EE\Utils\delem_log( 'site restart start' );
+		$args                 = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+		$all                  = EE\Utils\get_flag_value( $assoc_args, 'all' );
 		$no_service_specified = count( $assoc_args ) === 0;
 
 		$this->populate_site_info( $args );
@@ -262,7 +266,7 @@ abstract class EE_Site_Command {
 		foreach ( $containers as $container ) {
 			EE\Siteutils\run_compose_command( 'restart', $container );
 		}
-		\EE\Utils\delem_log( 'site restart stop' );
+		EE\Utils\delem_log( 'site restart stop' );
 	}
 
 	/**
@@ -280,9 +284,10 @@ abstract class EE_Site_Command {
 	 *
 	 */
 	public function reload( $args, $assoc_args, $whitelisted_containers = [], $reload_commands = [] ) {
-		\EE\Utils\delem_log( 'site reload start' );
-		$args = \EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
-		$all  = \EE\Utils\get_flag_value( $assoc_args, 'all' );
+
+		EE\Utils\delem_log( 'site reload start' );
+		$args = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
+		$all  = EE\Utils\get_flag_value( $assoc_args, 'all' );
 		if ( ! array_key_exists( 'nginx', $reload_commands ) ) {
 			$reload_commands['nginx'] = 'nginx sh -c \'nginx -t && service openresty reload\'';
 		}
@@ -297,15 +302,19 @@ abstract class EE_Site_Command {
 		} else {
 			$this->reload_services( array_keys( $assoc_args ), $reload_commands );
 		}
-		\EE\Utils\delem_log( 'site reload stop' );
+		EE\Utils\delem_log( 'site reload stop' );
 	}
 
 	/**
-	 * Executes reload commands. It needs seperate handling as commands to reload each service is different.
+	 * Executes reload commands. It needs separate handling as commands to reload each service is different.
+	 *
+	 * @param array $services        Services to reload.
+	 * @param array $reload_commands Commands to reload the services.
 	 */
 	private function reload_services( $services, $reload_commands ) {
+
 		foreach ( $services as $service ) {
-			\EE\SiteUtils\run_compose_command( 'exec', $reload_commands[$service], 'reload', $service );
+			EE\SiteUtils\run_compose_command( 'exec', $reload_commands[ $service ], 'reload', $service );
 		}
 	}
 
@@ -314,9 +323,10 @@ abstract class EE_Site_Command {
 	 *
 	 * @param string $site_name Name of the site for ssl.
 	 * @param string $site_root Webroot of the site.
-	 * @param bool   $wildcard  SSL with wildcard or not.
+	 * @param bool $wildcard    SSL with wildcard or not.
 	 */
 	protected function init_le( $site_name, $site_root, $wildcard = false ) {
+
 		$this->site_name = $site_name;
 		$this->site_root = $site_root;
 		$client          = new Site_Letsencrypt();
@@ -354,13 +364,14 @@ abstract class EE_Site_Command {
 	 * : Force renewal.
 	 */
 	public function le( $args = [], $assoc_args = [], $wildcard = false ) {
+
 		if ( ! isset( $this->site_name ) ) {
 			$this->populate_site_info( $args );
 		}
 		if ( ! isset( $this->le_mail ) ) {
 			$this->le_mail = EE::get_config( 'le-mail' ) ?? EE::input( 'Enter your mail id: ' );
 		}
-		$force   = \EE\Utils\get_flag_value( $assoc_args, 'force' );
+		$force   = EE\Utils\get_flag_value( $assoc_args, 'force' );
 		$domains = $wildcard ? [ "*.$this->site_name", $this->site_name ] : [ $this->site_name ];
 		$client  = new Site_Letsencrypt();
 		if ( ! $client->check( $domains, $wildcard ) ) {
@@ -382,7 +393,7 @@ abstract class EE_Site_Command {
 	 */
 	private function populate_site_info( $args ) {
 
-		$this->site_name = \EE\Utils\remove_trailing_slash( $args[0] );
+		$this->site_name = EE\Utils\remove_trailing_slash( $args[0] );
 
 		if ( EE::db()::site_in_db( $this->site_name ) ) {
 

--- a/php/init-ee.php
+++ b/php/init-ee.php
@@ -10,6 +10,7 @@ define( 'EE', true );
 define( 'EE_VERSION', trim( file_get_contents( EE_ROOT . '/VERSION' ) ) );
 define( 'EE_START_MICROTIME', microtime( true ) );
 define( 'EE_CONF_ROOT', '/opt/easyengine' );
+define( 'EE_PROXY_TYPE', 'ee-nginx-proxy' );
 
 if ( file_exists( EE_ROOT . '/vendor/autoload.php' ) ) {
 	define( 'EE_VENDOR_DIR', EE_ROOT . '/vendor' );

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -11,6 +11,7 @@ use \Symfony\Component\Filesystem\Filesystem;
  * @return bool|String Name of the site or false in failure.
  */
 function get_site_name() {
+
 	$sites = EE::db()::select( array( 'sitename' ) );
 
 	if ( $sites ) {
@@ -34,25 +35,27 @@ function get_site_name() {
 }
 
 /**
- * Function to set the site-name in the args when ee is running in a site folder and the site-name has not been passed in the args. If the site-name could not be found it will throw an error.
+ * Function to set the site-name in the args when ee is running in a site folder and the site-name has not been passed
+ * in the args. If the site-name could not be found it will throw an error.
  *
- * @param array   $args     The passed arguments.
- * @param String  $command  The command passing the arguments to auto-detect site-name.
- * @param String  $function The function passing the arguments to auto-detect site-name.
- * @param integer $arg_pos  Argument position where Site-name will be present.
+ * @param array $args      The passed arguments.
+ * @param String $command  The command passing the arguments to auto-detect site-name.
+ * @param String $function The function passing the arguments to auto-detect site-name.
+ * @param integer $arg_pos Argument position where Site-name will be present.
  *
  * @return array Arguments with site-name set.
  */
 function auto_site_name( $args, $command, $function, $arg_pos = 0 ) {
-	if ( isset( $args[$arg_pos] ) ) {
-		if ( EE::db()::site_in_db( $args[$arg_pos] ) ) {
+
+	if ( isset( $args[ $arg_pos ] ) ) {
+		if ( EE::db()::site_in_db( $args[ $arg_pos ] ) ) {
 			return $args;
 		}
 	}
 	$site_name = get_site_name();
 	if ( $site_name ) {
-		if ( isset( $args[$arg_pos] ) ) {
-			EE::error( $args[$arg_pos] . " is not a valid site-name. Did you mean `ee $command $function $site_name`?" );
+		if ( isset( $args[ $arg_pos ] ) ) {
+			EE::error( $args[ $arg_pos ] . " is not a valid site-name. Did you mean `ee $command $function $site_name`?" );
 		}
 		array_splice( $args, $arg_pos, 0, $site_name );
 	} else {
@@ -69,6 +72,7 @@ function auto_site_name( $args, $command, $function, $arg_pos = 0 ) {
  * Boots up the container if it is stopped or not running.
  */
 function init_checks() {
+
 	$proxy_type = EE_PROXY_TYPE;
 	if ( 'running' !== EE::docker()::container_status( $proxy_type ) ) {
 		/**
@@ -102,6 +106,7 @@ function init_checks() {
  * @param string $site_name Name of the site.
  */
 function create_site_root( $site_root, $site_name ) {
+
 	$fs = new Filesystem();
 	if ( $fs->exists( $site_root ) ) {
 		EE::error( "Webroot directory for site $site_name already exists." );
@@ -122,6 +127,7 @@ function create_site_root( $site_root, $site_name ) {
  * @throws \Exception when network start fails.
  */
 function setup_site_network( $site_name ) {
+
 	$proxy_type = EE_PROXY_TYPE;
 	if ( EE::docker()::create_network( $site_name ) ) {
 		EE::success( 'Network started.' );
@@ -137,9 +143,10 @@ function setup_site_network( $site_name ) {
  * Adds www to non-www redirection to site
  *
  * @param string $site_name Name of the site.
- * @param bool   $le        Specifying if letsencrypt is enabled or not.
+ * @param bool $le          Specifying if letsencrypt is enabled or not.
  */
 function add_site_redirects( $site_name, $le ) {
+
 	$fs               = new Filesystem();
 	$confd_path       = EE_CONF_ROOT . '/nginx/conf.d/';
 	$config_file_path = $confd_path . $site_name . '-redirect.conf';
@@ -219,6 +226,7 @@ function create_etc_hosts_entry( $site_name ) {
  * @throws \Exception when fails to connect to site.
  */
 function site_status_check( $site_name ) {
+
 	EE::log( 'Checking and verifying site-up status. This may take some time.' );
 	$httpcode = get_curl_info( $site_name );
 	$i        = 0;
@@ -270,6 +278,7 @@ function get_curl_info( $url, $port = 80, $port_info = false ) {
  * @throws \Exception when docker-compose up fails.
  */
 function start_site_containers( $site_root ) {
+
 	EE::log( 'Pulling latest images. This may take some time.' );
 	chdir( $site_root );
 	\EE\Utils\default_launch( 'docker-compose pull' );
@@ -282,8 +291,14 @@ function start_site_containers( $site_root ) {
 
 /**
  * Generic function to run a docker compose command. Must be ran inside correct directory.
+ *
+ * @param string $action             docker-compose action to run.
+ * @param string $container          The container on which action has to be run.
+ * @param string $action_to_display  The action message to be displayed.
+ * @param string $service_to_display The service message to be displayed.
  */
 function run_compose_command( $action, $container, $action_to_display = null, $service_to_display = null ) {
+
 	$display_action  = $action_to_display ? $action_to_display : $action;
 	$display_service = $service_to_display ? $service_to_display : $container;
 

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -36,25 +36,25 @@ function get_site_name() {
 /**
  * Function to set the site-name in the args when ee is running in a site folder and the site-name has not been passed in the args. If the site-name could not be found it will throw an error.
  *
- * @param array  $args     The passed arguments.
- * @param String $command  The command passing the arguments to auto-detect site-name.
- * @param String $function The function passing the arguments to auto-detect site-name.
- * @param bool   $arg_zero Site-name will be present in the first argument. Default true.
+ * @param array   $args     The passed arguments.
+ * @param String  $command  The command passing the arguments to auto-detect site-name.
+ * @param String  $function The function passing the arguments to auto-detect site-name.
+ * @param integer $arg_pos  Argument position where Site-name will be present.
  *
  * @return array Arguments with site-name set.
  */
-function auto_site_name( $args, $command, $function, $arg_zero = true ) {
-	if ( isset( $args[0] ) ) {
-		if ( EE::db()::site_in_db( $args[0] ) ) {
+function auto_site_name( $args, $command, $function, $arg_pos = 0 ) {
+	if ( isset( $args[$arg_pos] ) ) {
+		if ( EE::db()::site_in_db( $args[$arg_pos] ) ) {
 			return $args;
 		}
 	}
 	$site_name = get_site_name();
 	if ( $site_name ) {
-		if ( isset( $args[0] ) && $arg_zero ) {
-			EE::error( $args[0] . " is not a valid site-name. Did you mean `ee $command $function $site_name`?" );
+		if ( isset( $args[$arg_pos] ) ) {
+			EE::error( $args[$arg_pos] . " is not a valid site-name. Did you mean `ee $command $function $site_name`?" );
 		}
-		array_unshift( $args, $site_name );
+		array_splice( $args, $arg_pos, 0, $site_name );
 	} else {
 		EE::error( "Could not find the site you wish to run $command $function command on.\nEither pass it as an argument: `ee $command $function <site-name>` \nor run `ee $command $function` from inside the site folder." );
 	}

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -232,7 +232,7 @@ function site_status_check( $site_name ) {
 		EE::debug( "$site_name status httpcode: $httpcode" );
 		curl_exec( $ch );
 		$httpcode = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-		EE::log( '.' );
+		echo '.';
 		sleep( 2 );
 		if ( $i ++ > 60 ) {
 			break;

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace EE\SiteUtils;
+
+use \EE;
+use \Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Get the site-name from the path from where ee is running if it is a valid site path.
+ *
+ * @return bool|String Name of the site or false in failure.
+ */
+function get_site_name() {
+	$sites = EE::db()::select( array( 'sitename' ) );
+
+	if ( $sites ) {
+		$cwd          = getcwd();
+		$name_in_path = explode( '/', $cwd );
+		$site_name    = array_intersect( EE\Utils\array_flatten( $sites ), $name_in_path );
+
+		if ( 1 === count( $site_name ) ) {
+			$name = reset( $site_name );
+			$path = EE::db()::select( array( 'site_path' ), array( 'sitename' => $name ) );
+			if ( $path ) {
+				$site_path = $path[0]['site_path'];
+				if ( $site_path === substr( $cwd, 0, strlen( $site_path ) ) ) {
+					return $name;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Function to set the site-name in the args when ee is running in a site folder and the site-name has not been passed in the args. If the site-name could not be found it will throw an error.
+ *
+ * @param array  $args     The passed arguments.
+ * @param String $command  The command passing the arguments to auto-detect site-name.
+ * @param String $function The function passing the arguments to auto-detect site-name.
+ * @param bool   $arg_zero Site-name will be present in the first argument. Default true.
+ *
+ * @return array Arguments with site-name set.
+ */
+function auto_site_name( $args, $command, $function, $arg_zero = true ) {
+	if ( isset( $args[0] ) ) {
+		if ( EE::db()::site_in_db( $args[0] ) ) {
+			return $args;
+		}
+	}
+	$site_name = get_site_name();
+	if ( $site_name ) {
+		if ( isset( $args[0] ) && $arg_zero ) {
+			EE::error( $args[0] . " is not a valid site-name. Did you mean `ee $command $function $site_name`?" );
+		}
+		array_unshift( $args, $site_name );
+	} else {
+		EE::error( "Could not find the site you wish to run $command $function command on.\nEither pass it as an argument: `ee $command $function <site-name>` \nor run `ee $command $function` from inside the site folder." );
+	}
+
+	return $args;
+}

--- a/php/utils.php
+++ b/php/utils.php
@@ -1550,62 +1550,6 @@ function format_table( $items ) {
 }
 
 /**
- * Get the site-name from the path from where ee is running if it is a valid site path.
- *
- * @return bool|String Name of the site or false in failure.
- */
-function get_site_name() {
-	$sites = EE::db()::select( array( 'sitename' ) );
-
-	if ( $sites ) {
-		$cwd          = getcwd();
-		$name_in_path = explode( '/', $cwd );
-		$site_name    = array_intersect( array_flatten( $sites ), $name_in_path );
-
-		if ( 1 === count( $site_name ) ) {
-			$name = reset( $site_name );
-			$path = EE::db()::select( array( 'site_path' ), array( 'sitename' => $name ) );
-			if ( $path ) {
-				$site_path = $path[0]['site_path'];
-				if ( $site_path === substr( $cwd, 0, strlen( $site_path ) ) ) {
-					return $name;
-				}
-			}
-		}
-	}
-
-	return false;
-}
-
-/**
- * Function to set the site-name in the args when ee is running in a site folder and the site-name has not been passed in the args. If the site-name could not be found it will throw an error.
- *
- * @param array $args The passed arguments.
- * @param String $command The command passing the arguments to auto-detect site-name.
- * @param bool $arg_zero Site-name will be present in the first argument. Default true.
- *
- * @return array Arguments with site-name set.
- */
-function set_site_arg( $args, $command, $arg_zero=true ) {
-	if ( isset( $args[0] ) ) {
-		if ( EE::db()::site_in_db( $args[0] ) ) {
-			return $args;
-		}
-	}
-	$site_name = get_site_name();
-	if ( $site_name ) {
-		if ( isset( $args[0] ) && $arg_zero ) {
-			EE::error( $args[0] . " is not a valid site-name. Did you mean `ee $command $site_name`?" );
-		}
-		array_unshift( $args, $site_name );
-	} else {
-		EE::error( "Could not find the site you wish to run $command command on.\nEither pass it as an argument: `ee $command <site-name>` \nor run `ee $command` from inside the site folder." );
-	}
-
-	return $args;
-}
-
-/**
  * Function to flatten a multi-dimensional array.
  *
  * @param array $array Mulit-dimensional input array.


### PR DESCRIPTION
Closes: https://github.com/EasyEngine/easyengine/issues/1060

* Make Site-Command Abstract
* Add logic for routing according to `--type` parameter.
* Add functionality to ignore registration of public functions using `@ignorecommand` annotation.
* Add functionality to inherit command doc-comment from parent using `@inheritdoc` annotation.
* Add site-utils for common functions across site-packages.