### PR TITLE
Ssl wildcard all site types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ jobs:
       env: DEPLOY_BRANCH=master-v4
       after_success: ./ci/deploy.sh
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 branches:
   only:
     - develop-v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ jobs:
       env: DEPLOY_BRANCH=master-v4
       after_success: ./ci/deploy.sh
 
-cache:
-  directories:
-    - $HOME/.composer/cache
-
 branches:
   only:
     - develop-v4

--- a/php/class-ee-db.php
+++ b/php/class-ee-db.php
@@ -45,7 +45,7 @@ class EE_DB {
 			created_on DATETIME,
 			is_enabled BOOLEAN DEFAULT 1,
 			is_ssl BOOLEAN DEFAULT 0,
-			is_ssl_wildcard BOOLEAN DEFAULT 0,
+			site_ssl_wildcard BOOLEAN DEFAULT 0,
 			storage_fs VARCHAR,
 			storage_db VARCHAR,
 			db_name VARCHAR,

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -354,16 +354,16 @@ abstract class EE_Site_Command {
 		}
 
 		if ( ! $parent_site ) {
-			throw new Exception( 'Unable to find existing site: ' . $parent_site );
+			throw new Exception( 'Unable to find existing site: ' . $parent_site_name );
 		}
 
 
 		if ( ! $parent_site['is_ssl'] ) {
-			throw new Exception( "Cannot inherit from $parent_site as site does not have SSL cert" );
+			throw new Exception( "Cannot inherit from $parent_site_name as site does not have SSL cert" . var_dump( $parent_site ) );
 		}
 
 		if ( ! $parent_site['site_ssl_wildcard'] ) {
-			throw new Exception( "Cannot inherit from $parent_site as site does not have wildcard SSL cert" );
+			throw new Exception( "Cannot inherit from $parent_site_name as site does not have wildcard SSL cert" );
 		}
 
 		// We don't have to do anything now as nginx-proxy handles everything for us.

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -119,8 +119,8 @@ abstract class EE_Site_Command {
 
 		EE\Utils\delem_log( 'site delete start' );
 		$this->populate_site_info( $args );
-		EE::confirm( sprintf( 'Are you sure you want to delete %s?', $this->site['name'] ), $assoc_args );
-		$this->delete_site( 5, $this->site['name'], $this->site['root'] );
+		EE::confirm( sprintf( 'Are you sure you want to delete %s?', $this->site['url'] ), $assoc_args );
+		$this->delete_site( 5, $this->site['url'], $this->site['root'] );
 		EE\Utils\delem_log( 'site delete end' );
 	}
 
@@ -227,7 +227,7 @@ abstract class EE_Site_Command {
 		$force = EE\Utils\get_flag_value( $assoc_args, 'force' );
 		$args = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$this->populate_site_info( $args );
-		$site  = Site::find( $this->site['name'] );
+		$site  = Site::find( $this->site['url'] );
 
 		if ( $site->site_enabled && ! $force ) {
 			EE::error( sprintf( '%s is already enabled!', $site->site_url ) );
@@ -259,7 +259,7 @@ abstract class EE_Site_Command {
 		$args = EE\SiteUtils\auto_site_name( $args, 'site', __FUNCTION__ );
 		$this->populate_site_info( $args );
 
-		$site = Site::find($this->site['name']);
+		$site = Site::find($this->site['url']);
 
 		EE::log( sprintf( 'Disabling site %s.', $site->site_url ) );
 
@@ -267,9 +267,9 @@ abstract class EE_Site_Command {
 			$site->site_enabled = 0;
 			$site->save();
 
-			EE::success( sprintf( 'Site %s disabled.', $this->site['name'] ) );
+			EE::success( sprintf( 'Site %s disabled.', $this->site['url'] ) );
 		} else {
-			EE::error( sprintf( 'There was error in disabling %s. Please check logs.', $this->site['name'] ) );
+			EE::error( sprintf( 'There was error in disabling %s. Please check logs.', $this->site['url'] ) );
 		}
 		EE\Utils\delem_log( 'site disable end' );
 	}
@@ -424,7 +424,7 @@ abstract class EE_Site_Command {
 	protected function init_le( $site_name, $site_root, $wildcard = false ) {
 		EE::debug("Wildcard in init_le: $wildcard" );
 
-		$this->site['name'] = $site_name;
+		$this->site['url'] = $site_name;
 		$this->site['root'] = $site_root;
 		$this->wildcard = $wildcard;
 		$client = new Site_Letsencrypt();
@@ -444,7 +444,7 @@ abstract class EE_Site_Command {
 			return;
 		}
 		if ( $wildcard ) {
-			echo \cli\Colors::colorize( '%YIMPORTANT:%n Run `ee site le ' . $this->site['name'] . '` once the dns changes have propogated to complete the certification generation and installation.', null );
+			echo \cli\Colors::colorize( '%YIMPORTANT:%n Run `ee site le ' . $this->site['url'] . '` once the dns changes have propogated to complete the certification generation and installation.', null );
 		} else {
 			$this->le( [], [] );
 		}
@@ -502,7 +502,7 @@ abstract class EE_Site_Command {
 	 */
 	public function le( $args = [], $assoc_args = [] ) {
 
-		if ( !isset( $this->site['name'] ) ) {
+		if ( !isset( $this->site['url'] ) ) {
 			$this->populate_site_info( $args );
 		}
 
@@ -511,7 +511,7 @@ abstract class EE_Site_Command {
 		}
 
 		$force   = EE\Utils\get_flag_value( $assoc_args, 'force' );
-		$domains = $this->get_cert_domains( $this->site['name'], $this->wildcard );
+		$domains = $this->get_cert_domains( $this->site['url'], $this->wildcard );
 		$client  = new Site_Letsencrypt();
 
 		if ( ! $client->check( $domains, $this->wildcard ) ) {
@@ -519,8 +519,8 @@ abstract class EE_Site_Command {
 			return;
 		}
 
-		$san = array_values( array_diff( $domains, [ $this->site['name'] ] ) );
-		$client->request( $this->site['name'], $san, $this->le_mail, $force );
+		$san = array_values( array_diff( $domains, [ $this->site['url'] ] ) );
+		$client->request( $this->site['url'], $san, $this->le_mail, $force );
 
 		if ( ! $this->wildcard ) {
 			$client->cleanup( $this->site['root'] );
@@ -533,8 +533,8 @@ abstract class EE_Site_Command {
 	 */
 	private function populate_site_info( $args ) {
 
-		$this->site['name'] = EE\Utils\remove_trailing_slash( $args[0] );
-		$site = Site::find( $this->site['name'] );
+		$this->site['url'] = EE\Utils\remove_trailing_slash( $args[0] );
+		$site = Site::find( $this->site['url'] );
 		if ( $site ) {
 
 			$db_select = $site->site_url;
@@ -544,7 +544,7 @@ abstract class EE_Site_Command {
 			$this->ssl          = $site->site_ssl;
 			$this->wildcard     = $site->site_ssl_wildcard;
 		} else {
-			EE::error( sprintf( 'Site %s does not exist.', $this->site['name'] ) );
+			EE::error( sprintf( 'Site %s does not exist.', $this->site['url'] ) );
 		}
 	}
 

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -363,17 +363,12 @@ abstract class EE_Site_Command {
 	 * Runs the acme le registration and authorization.
 	 *
 	 * @param string $site_name      Name of the site for ssl.
-	 * @param string $needs_wildcard Does site needs wildcard.
 	 *
 	 * @throws Exception
 	 */
-	protected function inherit_certs( $site_name, $needs_wildcard ) {
+	protected function inherit_certs( $site_name ) {
 		$parent_site_name = implode( '.', array_slice( explode( '.', $site_name ), 1 ) );
 		$parent_site      = Site::find( $parent_site_name, [ 'site_ssl', 'site_ssl_wildcard' ] );
-
-		if ( $needs_wildcard ) {
-			throw new Exception( '--wildcard cannot be used with --ssl=inherit' );
-		}
 
 		if ( ! $parent_site ) {
 			throw new Exception( 'Unable to find existing site: ' . $parent_site_name );
@@ -407,8 +402,11 @@ abstract class EE_Site_Command {
 			EE::debug( 'Initializing LE' );
 			$this->init_le( $site_name, $site_root, $wildcard );
 		} elseif ( 'inherit' === $ssl_type ) {
+			if ( $wildcard ) {
+				EE::error( 'Cannot use --wildcard with --ssl=inherit', false );
+			}
 			EE::debug( 'Inheriting certs' );
-			$this->inherit_certs( $site_name, $wildcard );
+			$this->inherit_certs( $site_name );
 		} else {
 			EE::error( "Unrecognized value in --ssl flag: $ssl_type" );
 		}
@@ -422,7 +420,7 @@ abstract class EE_Site_Command {
 	 * @param bool   $wildcard  SSL with wildcard or not.
 	 */
 	protected function init_le( $site_name, $site_root, $wildcard = false ) {
-		EE::debug("Wildcard in init_le: $wildcard" );
+		EE::debug( "Wildcard in init_le: $wildcard" );
 
 		$this->site['url'] = $site_name;
 		$this->site['root'] = $site_root;

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -458,7 +458,7 @@ abstract class EE_Site_Command {
 	 */
 	private function get_cert_domains( string $site_name, $wildcard ) : array {
 		$domains = [ $site_name ];
-		$has_www = strpos( $site_name, 'www.' ) === 0;
+		$has_www = ( strpos( $site_name, 'www.' ) === 0 );
 
 		if ( $wildcard ) {
 			$domains[] = "*.{$site_name}";
@@ -477,7 +477,7 @@ abstract class EE_Site_Command {
 	 * @return string Domain name with or without www
 	 */
 	private function get_www_domain( string $site_name ) : string {
-		$has_www = strpos( $site_name, 'www.' ) === 0;
+		$has_www = ( strpos( $site_name, 'www.' ) === 0 );
 
 		if ( $has_www ) {
 			return ltrim( $site_name, 'www.' );

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -369,7 +369,6 @@ abstract class EE_Site_Command {
 			throw new Exception( 'Unable to find existing site: ' . $parent_site_name );
 		}
 
-
 		if ( ! $parent_site['is_ssl'] ) {
 			throw new Exception( "Cannot inherit from $parent_site_name as site does not have SSL cert" . var_dump( $parent_site ) );
 		}
@@ -382,7 +381,30 @@ abstract class EE_Site_Command {
 		EE::success( 'Inherited certs from parent' );
 	}
 
-		/**
+	/**
+	 * Runs SSL procedure.
+	 *
+	 * @param string $site_name Name of the site for ssl.
+	 * @param string $site_root Webroot of the site.
+	 * @param string $ssl_type  Type of ssl cert to issue.
+	 * @param bool   $wildcard  SSL with wildcard or not.
+	 *
+	 * @throws \EE\ExitException If --ssl flag has unrecognized value
+	 */
+	protected function init_ssl( $site_name, $site_root, $ssl_type, $wildcard = false ) {
+		EE::debug( 'Starting SSL procedure' );
+		if ( 'le' === $ssl_type ) {
+			EE::debug( 'Initializing LE' );
+			$this->init_le( $site_name, $site_root, $wildcard );
+		} elseif ( 'inherit' === $ssl_type ) {
+			EE::debug( 'Inheriting certs' );
+			$this->inherit_certs( $site_name, $wildcard );
+		} else {
+			EE::error( "Unrecognized value in --ssl flag: $ssl_type" );
+		}
+	}
+
+	/**
 	 * Runs the acme le registration and authorization.
 	 *
 	 * @param string $site_name Name of the site for ssl.

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -391,12 +391,23 @@ abstract class EE_Site_Command {
 			return;
 		}
 
-		$domains = $wildcard ? [
-			sprintf( '*.%s', $this->site['name'] ),
-			$this->site['name']
-		] : [ $this->site['name'] ];
+
+		$domains = [ $this->site['name'] ];
+		$has_www = strpos( $site_name, 'www.' ) === 0;
+
+		if ( $wildcard ) {
+			$domains[] = "*.{$this->site['name']}";
+		}
+
+		if ( $has_www ) {
+			$site_name_without_www = ltrim( $site_name, 'www.' );
+			$domains[]             = $site_name_without_www;
+		} else {
+			$site_name_with_www = 'www.' . $site_name;
+			$domains[]          = $site_name_with_www;
+		}
 		if ( ! $client->authorize( $domains, $this->site['root'], $wildcard ) ) {
-			$this->ssl = false;
+			$this->le = false;
 
 			return;
 		}

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -431,7 +431,7 @@ abstract class EE_Site_Command {
 		$this->le_mail = EE::get_runner()->config['le-mail'] ?? EE::input( 'Enter your mail id: ' );
 		EE::get_runner()->ensure_present_in_config( 'le-mail', $this->le_mail );
 		if ( ! $client->register( $this->le_mail ) ) {
-			$this->ssl = false;
+			$this->ssl = null;
 
 			return;
 		}
@@ -515,7 +515,7 @@ abstract class EE_Site_Command {
 		$client  = new Site_Letsencrypt();
 
 		if ( ! $client->check( $domains, $this->wildcard ) ) {
-			$this->ssl = false;
+			$this->ssl = null;
 			return;
 		}
 
@@ -541,8 +541,8 @@ abstract class EE_Site_Command {
 
 			$this->site['type'] = $site->site_type;
 			$this->site['root'] = $site->site_fs_path;
-			$this->ssl          = ( null !== $site->site_ssl );
-			$this->wildcard     = ( 'wildcard' === $site->site_ssl );
+			$this->ssl          = $site->site_ssl;
+			$this->wildcard     = $site->site_ssl_wildcard;
 		} else {
 			EE::error( sprintf( 'Site %s does not exist.', $this->site['name'] ) );
 		}

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -145,9 +145,9 @@ function setup_site_network( $site_name ) {
  * Adds www to non-www redirection to site
  *
  * @param string $site_name Name of the site.
- * @param bool $le          Specifying if letsencrypt is enabled or not.
+ * @param bool $ssl          Specifying if ssl is enabled or not.
  */
-function add_site_redirects( $site_name, $le ) {
+function add_site_redirects( $site_name, $ssl ) {
 
 	$fs               = new Filesystem();
 	$confd_path       = EE_CONF_ROOT . '/nginx/conf.d/';
@@ -157,7 +157,7 @@ function add_site_redirects( $site_name, $le ) {
 	if ( $has_www ) {
 		$site_name_without_www = ltrim( $site_name, '.www' );
 		// ee site create www.example.com --le
-		if ( $le ) {
+		if ( $ssl ) {
 			$content = "
 server {
 	listen  80;
@@ -177,7 +177,7 @@ server {
 	} else {
 		$site_name_with_www = 'www.' . $site_name;
 		// ee site create example.com --le
-		if ( $le ) {
+		if ( $ssl ) {
 
 			$content = "
 server {

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -142,6 +142,15 @@ function setup_site_network( $site_name ) {
 }
 
 /**
+ * Reloads configuration of ee-nginx-proxy container
+ *
+ * @return bool
+ */
+function reload_proxy_configuration() {
+	return EE::exec( 'docker exec ee-nginx-proxy sh -c "/app/docker-entrypoint.sh /usr/local/bin/docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf; /usr/sbin/nginx -s reload"' );
+}
+
+/**
  * Adds www to non-www redirection to site
  *
  * @param string $site_name Name of the site.

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -153,15 +153,21 @@ function reload_proxy_configuration() {
 /**
  * Adds www to non-www redirection to site
  *
- * @param string $site_name Name of the site.
- * @param bool $ssl          Specifying if ssl is enabled or not.
+ * @param string $site_name name of the site.
+ * @param bool $ssl         enable ssl or not.
+ * @param bool $inherit     inherit cert or not.
  */
-function add_site_redirects( $site_name, $ssl ) {
+function add_site_redirects( string $site_name, $ssl, $inherit ) {
 
 	$fs               = new Filesystem();
 	$confd_path       = EE_CONF_ROOT . '/nginx/conf.d/';
 	$config_file_path = $confd_path . $site_name . '-redirect.conf';
 	$has_www          = strpos( $site_name, 'www.' ) === 0;
+	$cert_site_name   = $site_name;
+
+	if ( $inherit ) {
+		$cert_site_name = implode( '.', array_slice( explode( '.', $site_name ), 1 ) );
+	}
 
 	if ( $has_www ) {
 		$site_name_without_www = ltrim( $site_name, '.www' );
@@ -182,8 +188,8 @@ server {
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/$site_name.crt;
-	ssl_certificate_key /etc/nginx/certs/$site_name.key;
+	ssl_certificate /etc/nginx/certs/$cert_site_name.crt;
+	ssl_certificate_key /etc/nginx/certs/$cert_site_name.key;
 	server_name  $site_name_without_www;
 	return  301 https://$site_name\$request_uri;
 }";
@@ -216,8 +222,8 @@ server {
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/$site_name.crt;
-	ssl_certificate_key /etc/nginx/certs/$site_name.key;
+	ssl_certificate /etc/nginx/certs/$cert_site_name.crt;
+	ssl_certificate_key /etc/nginx/certs/$cert_site_name.key;
 	server_name  $site_name_with_www;
 	return  301 https://$site_name\$request_uri;
 }";

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -178,10 +178,10 @@ function add_site_redirects( string $site_name, bool $ssl, bool $inherit ) {
 	}
 
 	$conf_data = [
-		'site_name' => $site_name,
+		'site_name'      => $site_name,
 		'cert_site_name' => $cert_site_name,
-		'server_name' => $server_name,
-		'ssl' => $ssl,
+		'server_name'    => $server_name,
+		'ssl'            => $ssl,
 	];
 
 	$content = EE\Utils\mustache_render( EE_ROOT . '/templates/redirect.conf.mustache', $conf_data );

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -161,7 +161,20 @@ function add_site_redirects( $site_name, $ssl ) {
 			$content = "
 server {
 	listen  80;
+	server_name  $site_name_without_www;
+	return  301 https://$site_name\$request_uri;
+}
+
+server {
 	listen  443;
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
+	ssl_prefer_server_ciphers on;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/$site_name.crt;
+	ssl_certificate_key /etc/nginx/certs/$site_name.key;
 	server_name  $site_name_without_www;
 	return  301 https://$site_name\$request_uri;
 }";
@@ -182,7 +195,20 @@ server {
 			$content = "
 server {
 	listen  80;
+	server_name  $site_name_with_www;
+	return  301 https://$site_name\$request_uri;
+}
+
+server {
 	listen  443;
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
+	ssl_prefer_server_ciphers on;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/$site_name.crt;
+	ssl_certificate_key /etc/nginx/certs/$site_name.key;
 	server_name  $site_name_with_www;
 	return  301 https://$site_name\$request_uri;
 }";

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -156,10 +156,10 @@ function reload_proxy_configuration() {
  * Adds www to non-www redirection to site
  *
  * @param string $site_name name of the site.
- * @param bool $ssl         enable ssl or not.
- * @param bool $inherit     inherit cert or not.
+ * @param bool   $ssl       enable ssl or not.
+ * @param bool   $inherit   inherit cert or not.
  */
-function add_site_redirects( string $site_name, $ssl, $inherit ) {
+function add_site_redirects( string $site_name, bool $ssl, bool $inherit ) {
 
 	$fs               = new Filesystem();
 	$confd_path       = EE_CONF_ROOT . '/nginx/conf.d/';
@@ -172,73 +172,19 @@ function add_site_redirects( string $site_name, $ssl, $inherit ) {
 	}
 
 	if ( $has_www ) {
-		$site_name_without_www = ltrim( $site_name, '.www' );
-		// ee site create www.example.com --le
-		if ( $ssl ) {
-			$content = "
-server {
-	listen  80;
-	server_name  $site_name_without_www;
-	return  301 https://$site_name\$request_uri;
-}
-
-server {
-	listen  443;
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
-	ssl_prefer_server_ciphers on;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/$cert_site_name.crt;
-	ssl_certificate_key /etc/nginx/certs/$cert_site_name.key;
-	server_name  $site_name_without_www;
-	return  301 https://$site_name\$request_uri;
-}";
-		} // ee site create www.example.com
-		else {
-			$content = "
-server {
-	listen  80;
-	server_name  $site_name_without_www;
-	return  301 http://$site_name\$request_uri;
-}";
-		}
+		$server_name = ltrim( $site_name, '.www' );
 	} else {
-		$site_name_with_www = 'www.' . $site_name;
-		// ee site create example.com --le
-		if ( $ssl ) {
-
-			$content = "
-server {
-	listen  80;
-	server_name  $site_name_with_www;
-	return  301 https://$site_name\$request_uri;
-}
-
-server {
-	listen  443;
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
-	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
-	ssl_prefer_server_ciphers on;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-	ssl_certificate /etc/nginx/certs/$cert_site_name.crt;
-	ssl_certificate_key /etc/nginx/certs/$cert_site_name.key;
-	server_name  $site_name_with_www;
-	return  301 https://$site_name\$request_uri;
-}";
-		} // ee site create example.com
-		else {
-			$content = "
-server {
-	listen  80;
-	server_name  $site_name_with_www;
-	return  301 http://$site_name\$request_uri;
-}";
-		}
+		$server_name = 'www.' . $site_name;
 	}
+
+	$conf_data = [
+		'site_name' => $site_name,
+		'cert_site_name' => $cert_site_name,
+		'server_name' => $server_name,
+		'ssl' => $ssl,
+	];
+
+	$content = EE\Utils\mustache_render( EE_ROOT . '/templates/redirect.conf.mustache', $conf_data );
 	$fs->dumpFile( $config_file_path, ltrim( $content, PHP_EOL ) );
 }
 

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -232,7 +232,7 @@ function site_status_check( $site_name ) {
 	EE::log( 'Checking and verifying site-up status. This may take some time.' );
 	$httpcode = get_curl_info( $site_name );
 	$i        = 0;
-	while ( 200 !== $httpcode && 302 !== $httpcode ) {
+	while ( 200 !== $httpcode && 302 !== $httpcode && 301 !== $httpcode ) {
 		EE::debug( "$site_name status httpcode: $httpcode" );
 		$httpcode = get_curl_info( $site_name );
 		echo '.';
@@ -241,7 +241,7 @@ function site_status_check( $site_name ) {
 			break;
 		}
 	}
-	if ( 200 !== $httpcode && 302 !== $httpcode ) {
+	if ( 200 !== $httpcode && 302 !== $httpcode && 301 !== $httpcode ) {
 		throw new \Exception( 'Problem connecting to site!' );
 	}
 
@@ -260,8 +260,8 @@ function get_curl_info( $url, $port = 80, $port_info = false ) {
 
 	$ch = curl_init( $url );
 	curl_setopt( $ch, CURLOPT_HEADER, true );
-	curl_setopt( $ch, CURLOPT_NOBODY, true );
 	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, 1 );
+	curl_setopt( $ch, CURLOPT_NOBODY, true );
 	curl_setopt( $ch, CURLOPT_TIMEOUT, 10 );
 	curl_setopt( $ch, CURLOPT_PORT, $port );
 	curl_exec( $ch );

--- a/templates/redirect.conf.mustache
+++ b/templates/redirect.conf.mustache
@@ -1,0 +1,20 @@
+server {
+	listen  80;
+	server_name  {{server_name}};
+	return  301 {{#ssl}}https://{{/ssl}}{{^ssl}}http://{{/ssl}}{{site_name}}$request_uri;
+}
+{{#ssl}}
+server {
+	listen  443;
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
+	ssl_prefer_server_ciphers on;
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/{{cert_site_name}}.crt;
+	ssl_certificate_key /etc/nginx/certs/{{cert_site_name}}.key;
+	server_name  {{server_name}};
+	return  301 https://{{site_name}}$request_uri;
+}
+{{/ssl}}

--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -172,7 +172,6 @@ $finder
 	->in(EE_VENDOR_DIR . '/acmephp')
 	->in(EE_VENDOR_DIR . '/league')
 	->in(EE_VENDOR_DIR . '/webmozart')
-
 	->notName('behat-tags.php')
 	->notPath('#(?:[^/]+-command|php-cli-tools)/vendor/#') // For running locally, in case have composer installed or symlinked them.
 	->exclude('examples')
@@ -180,8 +179,8 @@ $finder
 	->exclude('test')
 	->exclude('tests')
 	->exclude('Test')
-	->exclude('Tests')
-	;
+	->exclude('Tests');
+
 if ( 'cli' === BUILD ) {
 	$finder
 		->in(EE_VENDOR_DIR . '/wp-cli/mustangostang-spyc')
@@ -217,6 +216,21 @@ if ( 'cli' === BUILD ) {
 		->exclude('composer/composer/src/Composer/SelfUpdate')
 		;
 }
+
+foreach ( $finder as $file ) {
+	add_file( $phar, $file );
+}
+
+$finder = new Finder();
+$finder
+	->files()
+	->ignoreVCS(true)
+	->name('img-versions.json')
+	->in( EE_ROOT )
+	->exclude( EE_ROOT . 'php/')
+	->exclude( EE_ROOT . 'templates/')
+	->exclude( EE_ROOT . 'vendor/')
+;
 
 foreach ( $finder as $file ) {
 	add_file( $phar, $file );


### PR DESCRIPTION
Issue ref: https://github.com/EasyEngine/easyengine/issues/1170 and https://github.com/EasyEngine/site-command/issues/77

Other than that, this PR  - 
1. corrects SSL behaviour as discussed with team(use --ssl and --wildcard instead of --le).
2. Adds WWW domain while requesting cert - https://github.com/EasyEngine/easyengine/pull/1171/commits/c57626365d16e2f3d863c9a6c8adae92a6b849c2
3. Adds function to reload ee-nginx-proxy container - https://github.com/EasyEngine/easyengine/pull/1171/commits/192fdc45a18ab116834e8dd74ee9ecb4586f270a
4. Fix http challenge creation - https://github.com/EasyEngine/easyengine/pull/1171/commits/6977a1df104fbcf4f788541d51e8d07d5ccc3314
5. Add ability to inherit cert - https://github.com/EasyEngine/easyengine/pull/1171/commits/f74c8e199030ba9103e3294558a67afa7db29398


Related PRs:
https://github.com/EasyEngine/site-command/pull/98
https://github.com/EasyEngine/site-wp-command/pull/17
https://github.com/EasyEngine/shell-command/pull/5

closes #1170 and closes #77