### PR TITLE
Move global containers to docker-compose

### DIFF
--- a/php/class-ee-docker.php
+++ b/php/class-ee-docker.php
@@ -171,6 +171,13 @@ class EE_DOCKER {
 		return false;
 	}
 
+	/**
+	 * Function to check if a network exists
+	 *
+	 * @param string $network Name/ID of network to check
+	 *
+	 * @return bool Network exists or not
+	 */
 	public static function docker_network_exists( string $network ) {
 		return EE::exec( "docker network inspect $network" );
 	}

--- a/php/class-ee-docker.php
+++ b/php/class-ee-docker.php
@@ -171,6 +171,10 @@ class EE_DOCKER {
 		return false;
 	}
 
+	public static function docker_network_exists( string $network ) {
+		return EE::exec( "docker network inspect $network" );
+	}
+
 	/**
 	 * Function to destroy the containers.
 	 *

--- a/php/class-ee-site.php
+++ b/php/class-ee-site.php
@@ -149,18 +149,6 @@ abstract class EE_Site_Command {
 					EE::warning( 'Error in removing docker containers.' );
 				}
 			}
-
-			EE::docker()::disconnect_site_network_from( $site_name, $proxy_type );
-		}
-
-		if ( $level >= 2 ) {
-			if ( EE::docker()::rm_network( $site_name ) ) {
-				EE::log( "[$site_name] Docker container removed from network $proxy_type." );
-			} else {
-				if ( $level > 2 ) {
-					EE::warning( "Error in removing Docker container from network $proxy_type" );
-				}
-			}
 		}
 
 		if ( $this->fs->exists( $site_root ) ) {

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -95,7 +95,7 @@ function init_checks() {
 
 			$EE_CONF_ROOT = EE_CONF_ROOT;
 			if ( ! EE::docker()::docker_network_exists( 'ee-global-network' ) ) {
-				if ( ! EE::exec( 'docker network create ee-global-network' ) ) {
+				if ( ! EE::docker()::create_network( 'ee-global-network' ) ) {
 					EE::error( 'Unable to create network ee-global-network' );
 				}
 			}

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -137,7 +137,6 @@ function generate_global_docker_compose_yml( Filesystem $fs ) {
 				EE_CONF_ROOT . '/nginx/conf.d:/etc/nginx/conf.d',
 				EE_CONF_ROOT . '/nginx/htpasswd:/etc/nginx/htpasswd',
 				EE_CONF_ROOT . '/nginx/vhost.d:/etc/nginx/vhost.d',
-				EE_CONF_ROOT . ':/app/ee4',
 				'/usr/share/nginx/html',
 				'/var/run/docker.sock:/tmp/docker.sock:ro',
 			],

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -139,7 +139,6 @@ function generate_global_docker_compose_yml( Filesystem $fs ) {
 			],
 			'networks'       => [
 				'global-network',
-				'site-network',
 			],
 		],
 	];
@@ -166,26 +165,6 @@ function create_site_root( $site_root, $site_name ) {
 
 	$fs->mkdir( $site_root );
 	$fs->chown( $site_root, $terminal_username );
-}
-
-/**
- * Function to setup site network.
- *
- * @param string $site_name Name of the site.
- *
- * @throws \Exception when network start fails.
- */
-function setup_site_network( $site_name ) {
-
-	$proxy_type = EE_PROXY_TYPE;
-	if ( EE::docker()::create_network( $site_name ) ) {
-		EE::success( 'Network started.' );
-	} else {
-		throw new \Exception( 'There was some error in starting the network.' );
-	}
-
-	EE::docker()::connect_site_network_to( $site_name, $proxy_type );
-
 }
 
 /**

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -86,13 +86,20 @@ function init_checks() {
 		if ( ! ( $port_80_status && $port_443_status ) ) {
 			EE::error( 'Cannot create/start proxy container. Please make sure port 80 and 443 are free.' );
 		} else {
-			$EE_CONF_ROOT     = EE_CONF_ROOT;
-			$img_versions     = EE\Utils\get_image_versions();
-			$ee_proxy_command = "docker run --name $proxy_type -e LOCAL_USER_ID=`id -u` -e LOCAL_GROUP_ID=`id -g` --restart=always -d -p 80:80 -p 443:443 -v $EE_CONF_ROOT/nginx/certs:/etc/nginx/certs -v $EE_CONF_ROOT/nginx/dhparam:/etc/nginx/dhparam -v $EE_CONF_ROOT/nginx/conf.d:/etc/nginx/conf.d -v $EE_CONF_ROOT/nginx/htpasswd:/etc/nginx/htpasswd -v $EE_CONF_ROOT/nginx/vhost.d:/etc/nginx/vhost.d -v /var/run/docker.sock:/tmp/docker.sock:ro -v $EE_CONF_ROOT:/app/ee4 -v /usr/share/nginx/html easyengine/nginx-proxy:" . $img_versions['easyengine/nginx-proxy'];
 
+			$fs = new Filesystem();
 
-			if ( EE::docker()::boot_container( $proxy_type, $ee_proxy_command ) ) {
-				$fs = new Filesystem();
+			if ( ! $fs->exists( EE_CONF_ROOT . '/docker-compose.yml' ) ) {
+				generate_global_docker_compose_yml( $fs );
+			}
+
+			$EE_CONF_ROOT = EE_CONF_ROOT;
+			if ( ! EE::docker()::docker_network_exists( 'ee-global-network' ) ) {
+				if ( ! EE::exec( 'docker network create ee-global-network' ) ) {
+					EE::error( 'Unable to create network ee-global-network' );
+				}
+			}
+			if ( EE::docker()::docker_compose_up( EE_CONF_ROOT, [ 'nginx-proxy' ] ) ) {
 				$fs->dumpFile( "$EE_CONF_ROOT/nginx/conf.d/custom.conf", file_get_contents( EE_ROOT . '/templates/custom.conf.mustache' ) );
 				EE::success( "$proxy_type container is up." );
 			} else {
@@ -100,6 +107,44 @@ function init_checks() {
 			}
 		}
 	}
+}
+
+
+function generate_global_docker_compose_yml( Filesystem $fs ) {
+	$img_versions = EE\Utils\get_image_versions();
+
+	$data     = [
+		'services' => [
+			'name'           => 'nginx-proxy',
+			'container_name' => 'ee-nginx-proxy',
+			'image'          => 'easyengine/nginx-proxy:' . $img_versions['easyengine/nginx-proxy'],
+			'restart'        => 'always',
+			'ports'          => [
+				'80:80',
+				'443:443',
+			],
+			'environment'    => [
+				'LOCAL_USER_ID=' . posix_geteuid(),
+				'LOCAL_GROUP_ID=' . posix_getegid(),
+			],
+			'volumes'        => [
+				EE_CONF_ROOT . '/nginx/certs:/etc/nginx/certs ',
+				EE_CONF_ROOT . '/nginx/dhparam:/etc/nginx/dhparam',
+				EE_CONF_ROOT . '/nginx/conf.d:/etc/nginx/conf.d',
+				EE_CONF_ROOT . '/nginx/htpasswd:/etc/nginx/htpasswd',
+				EE_CONF_ROOT . '/nginx/vhost.d:/etc/nginx/vhost.d',
+				EE_CONF_ROOT . ':/app/ee4',
+				'/usr/share/nginx/html',
+				'/var/run/docker.sock:/tmp/docker.sock:ro',
+			],
+			'networks'       => [
+				'global-network',
+				'site-network',
+			],
+		],
+	];
+	$contents = EE\Utils\mustache_render( EE_ROOT . '/templates/global_docker_compose.yml.mustache', $data );
+	$fs->dumpFile( EE_CONF_ROOT . '/docker-compose.yml', $contents );
 }
 
 /**

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -128,7 +128,7 @@ function generate_global_docker_compose_yml( Filesystem $fs ) {
 				'LOCAL_GROUP_ID=' . posix_getegid(),
 			],
 			'volumes'        => [
-				EE_CONF_ROOT . '/nginx/certs:/etc/nginx/certs ',
+				EE_CONF_ROOT . '/nginx/certs:/etc/nginx/certs',
 				EE_CONF_ROOT . '/nginx/dhparam:/etc/nginx/dhparam',
 				EE_CONF_ROOT . '/nginx/conf.d:/etc/nginx/conf.d',
 				EE_CONF_ROOT . '/nginx/htpasswd:/etc/nginx/htpasswd',

--- a/php/site-utils.php
+++ b/php/site-utils.php
@@ -109,7 +109,11 @@ function init_checks() {
 	}
 }
 
-
+/**
+ * Generates global docker-compose.yml at EE_CONF_ROOT
+ *
+ * @param Filesystem $fs Filesystem object to write file
+ */
 function generate_global_docker_compose_yml( Filesystem $fs ) {
 	$img_versions = EE\Utils\get_image_versions();
 
@@ -142,6 +146,7 @@ function generate_global_docker_compose_yml( Filesystem $fs ) {
 			],
 		],
 	];
+
 	$contents = EE\Utils\mustache_render( EE_ROOT . '/templates/global_docker_compose.yml.mustache', $data );
 	$fs->dumpFile( EE_CONF_ROOT . '/docker-compose.yml', $contents );
 }

--- a/templates/global_docker_compose.yml.mustache
+++ b/templates/global_docker_compose.yml.mustache
@@ -1,0 +1,55 @@
+version: '3'
+
+services:
+
+{{#services}}
+  {{name}}:
+    container_name: {{container_name}}
+    image: {{image}}
+  {{#ports.0}}
+    ports:
+    {{#ports}}
+      - "{{.}}"
+    {{/ports}}
+  {{/ports.0}}
+  {{#depends_on}}
+    depends_on:
+      - {{.}}
+  {{/depends_on}}
+  {{#restart}}
+    restart: {{.}}
+  {{/restart}}
+  {{#command}}
+    command: {{.}}
+  {{/command}}
+  {{#labels.0}}
+    labels:
+    {{#labels}}
+      - "{{.}}"
+    {{/labels}}
+  {{/labels.0}}
+  {{#volumes.0}}
+    volumes:
+    {{#volumes}}
+      - "{{.}}"
+    {{/volumes}}
+  {{/volumes.0}}
+  {{#environment.0}}
+    environment:
+    {{#environment}}
+      - {{.}}
+    {{/environment}}
+  {{/environment.0}}
+  {{#networks.0}}
+    networks:
+    {{#networks}}
+      - {{.}}
+    {{/networks}}
+  {{/networks.0}}
+{{/services}}
+
+networks:
+  site-network:
+  global-network:
+    external:
+      name: ee-global-network

--- a/templates/global_docker_compose.yml.mustache
+++ b/templates/global_docker_compose.yml.mustache
@@ -49,7 +49,6 @@ services:
 {{/services}}
 
 networks:
-  site-network:
   global-network:
     external:
       name: ee-global-network


### PR DESCRIPTION
Moves global containers like `ee-cron-scheduler` and `ee-nginx-proxy` to global `docker-compose.yml`. This way "services" in easyengine can then easily be managed by service command - https://github.com/EasyEngine/easyengine/issues/1010.

Earlier it used to be that there was a single network per site and nginx-proxy was connected to it.
Now there is a special `ee-global-network` network. All nginx containers of all sites will be connected to it and there will be seperate site-name network in which all containers of same site will connect. 

Depends on - https://github.com/EasyEngine/site-command/pull/99 and https://github.com/EasyEngine/site-wp-command/pull/24

**NOTE**: Travis-CI will not pass until dependent PRs are merged