### PR TITLE
Remove custom conf template

### DIFF
--- a/templates/custom.conf.mustache
+++ b/templates/custom.conf.mustache
@@ -1,2 +1,0 @@
-server_tokens off;
-client_max_body_size 100m;


### PR DESCRIPTION
Removing this custom conf template as it is now added in the nginx template by: EasyEngine/dockerfiles#47

Signed-off-by: Riddhesh Sanghvi riddheshsanghvi96@gmail.com