### PR TITLE
Add ralouphie/getallheaders in the phar

### DIFF
--- a/utils/make-phar.php
+++ b/utils/make-phar.php
@@ -170,6 +170,7 @@ $finder
 	->in(EE_VENDOR_DIR . '/symfony/polyfill-ctype')
 	->in(EE_VENDOR_DIR . '/monolog')
 	->in(EE_VENDOR_DIR . '/guzzlehttp')
+	->in(EE_VENDOR_DIR . '/ralouphie/getallheaders')
 	->in(EE_VENDOR_DIR . '/acmephp')
 	->in(EE_VENDOR_DIR . '/league')
 	->in(EE_VENDOR_DIR . '/webmozart')


### PR DESCRIPTION
Builds are failing due to missing files in phar.
https://travis-ci.org/abhijitrakas/site-type-php/jobs/462656839

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>