### PR TITLE
redirection is not needed for https url

### DIFF
--- a/templates/redirect.conf.mustache
+++ b/templates/redirect.conf.mustache
@@ -15,6 +15,6 @@ server {
 	ssl_certificate /etc/nginx/certs/{{cert_site_name}}.crt;
 	ssl_certificate_key /etc/nginx/certs/{{cert_site_name}}.key;
 	server_name  {{server_name}};
-	return  301 https://{{site_name}}$request_uri;
+	#return  301 https://{{site_name}}$request_uri;
 }
 {{/ssl}}


### PR DESCRIPTION
You want http to https redirection but adding another redirection from https to https creates a redirection loop.