### PR TITLE
Disable cli update for macOS

### DIFF
--- a/php/commands/src/CLI_Command.php
+++ b/php/commands/src/CLI_Command.php
@@ -260,6 +260,9 @@ class CLI_Command extends EE_Command {
 		if ( ! Utils\inside_phar() ) {
 			EE::error( 'You can only self-update Phar files.' );
 		}
+		if ( IS_DARWIN ) {
+			EE::error( 'Please use `brew upgrade easyengine` to update EasyEngine on macOS.' );
+		}
 		$old_phar = realpath( $_SERVER['argv'][0] );
 		if ( ! is_writable( $old_phar ) ) {
 			EE::error( sprintf( '%s is not writable by current user.', $old_phar ) );


### PR DESCRIPTION
Disable cli update for macOS, instead prompt to run `brew upgrade easyengine`.

Signed-off-by: Riddhesh Sanghvi <riddheshsanghvi96@gmail.com>