### PR TITLE
Update phar build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ install:
   - |
     # Run composer install for master else update.
     if [[ "$TRAVIS_BRANCH" = "master" ]]; then
-      composer install --no-interaction
+      composer install --prefer-dist --no-suggest --no-progress --no-interaction
     else
-      composer update
+      composer update --prefer-dist --no-suggest --no-progress --no-interaction
     fi
   - sudo ./ci/test-env-install.sh
 

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -30,6 +30,16 @@ set -x
 # add github's public key
 echo "|1|qPmmP7LVZ7Qbpk7AylmkfR0FApQ=|WUy1WS3F4qcr3R5Sc728778goPw= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
 
+# Remove dev dependenices needed for testing
+if [[ "$TRAVIS_BRANCH" = "master" ]]; then
+	composer install --prefer-dist --no-suggest --no-progress --no-interaction --no-dev
+else
+	composer update --prefer-dist --no-suggest --no-progress --no-interaction --no-dev
+fi
+
+# Re create phar
+bash "$TRAVIS_BUILD_DIR/ci/prepare.sh"
+
 git clone git@github.com:easyengine/easyengine-builds.git
 
 git config --global user.name "rtBot"

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,7 @@
         "symfony/translation": "3.4.18",
         "symfony/yaml": "3.4.18",
         "wp-cli/mustangostang-spyc": "0.6.3",
-        "wp-cli/php-cli-tools": "0.11.10",
-        "ext-json": "*"
+        "wp-cli/php-cli-tools": "0.11.10"
     },
     "require-dev": {
         "behat/behat": "3.7.0",


### PR DESCRIPTION
Remove dev dependencies before creating phar for deployment as they have special ext requirements that are not needed by default in EE.