### PR TITLE
Fix docker-compose command being ran on cli, config and help

### DIFF
--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -69,17 +69,18 @@ class Runner {
 			$check_requirements = ( [ 'site', 'cmd-dump' ] === $this->arguments ) ? false : $check_requirements;
 		}
 
-		$nginx_proxy = 'services_global-nginx-proxy_1';
-		$launch      = EE::launch( sprintf( 'cd %s && docker ps -q --no-trunc | grep $(docker-compose ps -q global-nginx-proxy)', EE_SERVICE_DIR ) );
-		if ( 0 === $launch->return_code ) {
-			$nginx_proxy = trim( $launch->stdout );
-		}
-		define( 'EE_PROXY_TYPE', $nginx_proxy );
-
 		if ( $check_requirements ) {
+			$nginx_proxy = 'services_global-nginx-proxy_1';
+			$launch      = EE::launch( sprintf( 'cd %s && docker ps -q --no-trunc | grep $(docker-compose ps -q global-nginx-proxy)', EE_SERVICE_DIR ) );
+			if ( 0 === $launch->return_code ) {
+				$nginx_proxy = trim( $launch->stdout );
+			}
+			define( 'EE_PROXY_TYPE', $nginx_proxy );
+	
 			$this->check_requirements();
 			$this->maybe_trigger_migration();
 		}
+
 		if ( [ 'cli', 'info' ] === $this->arguments && $this->check_requirements( false ) ) {
 			$this->maybe_trigger_migration();
 		}


### PR DESCRIPTION
docker-compose command for `EE_PROXY_TYPE` will not run on `ee` -> `cli`, `config` and `help`
:heavy_check_mark: Improves performance.