### PR TITLE
Faster ee load

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "monolog/monolog": "1.24.0",
         "mustache/mustache": "2.12.0",
         "rmccue/requests": "1.7.0",
+        "seld/cli-prompt": "^1.0",
         "symfony/config": "3.4.18",
         "symfony/console": "3.4.18",
         "symfony/debug": "3.4.18",

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -65,7 +65,7 @@ class Runner {
 
 		$check_requirements = false;
 		if ( ! empty( $this->arguments ) ) {
-			$check_requirements = in_array( $this->arguments[0], [ 'cli', 'config', 'help' ], true ) ? false : true;
+			$check_requirements = in_array( $this->arguments[0], [ 'log', 'shell', 'cron', 'auth', 'admin-tools', 'mailhog', 'config', 'site', 'cli', 'config', 'help' ], true ) ? false : true;
 			$check_requirements = ( [ 'site', 'cmd-dump' ] === $this->arguments ) ? false : $check_requirements;
 		}
 
@@ -274,7 +274,6 @@ class Runner {
 			$full_name = implode( ' ', $cmd_path );
 
 			$subcommand = $command->find_subcommand( $args );
-
 			if ( ! $subcommand ) {
 				if ( count( $cmd_path ) > 1 ) {
 					$child = array_pop( $cmd_path );
@@ -326,7 +325,6 @@ class Runner {
 		}
 
 		list( $command, $final_args, $cmd_path ) = $r;
-
 		$name = implode( ' ', $cmd_path );
 
 		$extra_args = array();


### PR DESCRIPTION
Regarding this [issue](https://github.com/EasyEngine/easyengine/issues/1491), I found that `ee` can load faster if we skip the checking for following commands: 
`'log', 'shell', 'cron', 'auth', 'admin-tools', 'mailhog', 'config', 'site'`
Also, by disabling this check, auto complete will work much faster then before. 
Basically the checking is to verify that the main nginx proxy is running before executing any command directly to container, so if we still need this check then we can move it to the method `run_command()` instead of doing it when `ee` get initialized.