### PR TITLE
Add PHP 8.0 support in site create

### DIFF
--- a/img-versions.json
+++ b/img-versions.json
@@ -10,6 +10,7 @@
     "easyengine/php7.2": "v4.1.7",
     "easyengine/php7.3": "v4.1.7",
     "easyengine/php7.4": "v4.1.7",
+    "easyengine/php8.0": "v4.2.0",
     "easyengine/postfix": "v4.1.5",
     "easyengine/redis": "v4.1.4",
     "easyengine/newrelic-daemon": "v4.0.0"

--- a/php/EE/Migration/Containers.php
+++ b/php/EE/Migration/Containers.php
@@ -33,6 +33,7 @@ class Containers {
 			'easyengine/php7.2',
 			'easyengine/php7.3',
 			'easyengine/php7.4',
+			'easyengine/php8.0',
 			'easyengine/newrelic-daemon',
 		];
 


### PR DESCRIPTION
I've ensured that the default is still 7.4. If `--php=8.0` is specified, only then 8.0 site will be created

Depends on:
https://github.com/EasyEngine/site-command/pull/380
https://github.com/EasyEngine/site-type-php/pull/85
https://github.com/EasyEngine/site-type-wp/pull/192