### PR TITLE
`EE::notice()` support

### DIFF
--- a/php/EE/Loggers/Regular.php
+++ b/php/EE/Loggers/Regular.php
@@ -42,12 +42,21 @@ class Regular extends Base {
 	}
 
 	/**
-	 * Write an message to STDERR, prefixed with "Error: ".
+	 * Write a message to STDERR, prefixed with "Error: ".
 	 *
 	 * @param string $message Message to write.
 	 */
 	public function error( $message ) {
 		$this->_line( $message, 'Error', '%R', STDERR );
+	}
+
+	/**
+	 * Write a message, prefixed with "Notice: ".
+	 *
+	 * @param string $message Message to write.
+	 */
+	public function notice( $message ) {
+		$this->_line( $message, 'Notice', '%y' );
 	}
 
 	/**

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -785,7 +785,7 @@ class Runner {
 				( 'create' === $this->arguments[1] ? 'add' : 'remove' )
 			);
 
-			EE::warning( $deprecation_warn );
+			EE::notice( $deprecation_warn );
 		}
 
 		// Protect 'cli info' from most of the runtime,

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -780,7 +780,7 @@ class Runner {
 		// Print a deprecation warning if 'create' or 'delete' is being used (ee auth).
 		if ( 'auth' === $this->arguments[0] && ( 'create' === $this->arguments[1] || 'delete' === $this->arguments[1] ) ) {
 			$deprecation_warn = sprintf(
-				'`%1$s` is deprecated and will be replaced with `%2$s` instead. See: `ee auth %2$s`',
+				'`%1$s` is deprecated and will be replaced with `%2$s`. See: `ee auth %2$s`',
 				$this->arguments[1],
 				( 'create' === $this->arguments[1] ? 'add' : 'remove' )
 			);

--- a/php/EE/Runner.php
+++ b/php/EE/Runner.php
@@ -777,6 +777,17 @@ class Runner {
 			$this->arguments[] = 'help';
 		}
 
+		// Print a deprecation warning if 'create' or 'delete' is being used (ee auth).
+		if ( 'auth' === $this->arguments[0] && ( 'create' === $this->arguments[1] || 'delete' === $this->arguments[1] ) ) {
+			$deprecation_warn = sprintf(
+				'`%1$s` is deprecated and will be replaced with `%2$s` instead. See: `ee auth %2$s`',
+				$this->arguments[1],
+				( 'create' === $this->arguments[1] ? 'add' : 'remove' )
+			);
+
+			EE::warning( $deprecation_warn );
+		}
+
 		// Protect 'cli info' from most of the runtime,
 		// except when the command will be run over SSH
 		if ( ! empty( $this->arguments[0] ) && 'cli' === $this->arguments[0] && ! empty( $this->arguments[1] ) && 'info' === $this->arguments[1] ) {

--- a/php/class-ee.php
+++ b/php/class-ee.php
@@ -573,6 +573,17 @@ class EE {
 	}
 
 	/**
+	 * Display notice message prefixed with "Notice: ".
+	 *
+	 * @param string $message Message to write.
+	 *
+	 * @return null
+	 */
+	public static function notice( $message ) {
+		self::$logger->notice( self::error_to_string( $message ) );
+	}
+
+	/**
 	 * Display error message prefixed with "Error: " and exit script.
 	 *
 	 * Error message is written to STDERR. Defaults to halting script execution


### PR DESCRIPTION
### What's changed
Instead of using `EE::warning()`  to output (deprecation) notices, `EE::notice()` can be used. `EE::notice()` will print a nice deprecation notice prefixed with "Notice: " in yellow.
It is being used for printing deprecation notices while using `ee auth create/delete`.

### Files
- `php/EE/Loggers/Regular.php`
- `php/EE/Runner.php`
- `php/class-ee.php`
