### PR TITLE
feat(migrations): implement concurrent docker image pulls

### DIFF
--- a/migrations/db/20181016052850_easyengine_insert_docker_images_version.php
+++ b/migrations/db/20181016052850_easyengine_insert_docker_images_version.php
@@ -4,6 +4,7 @@ namespace EE\Migration;
 
 use EE;
 use EE\Migration\Base;
+use Symfony\Component\Process\Process;
 
 class InsertDockerImagesVersion extends Base {
 
@@ -37,18 +38,51 @@ class InsertDockerImagesVersion extends Base {
 			'easyengine/php7.2',
 			'easyengine/php7.3',
 			'easyengine/php7.4',
+			'easyengine/php',
 			'easyengine/php8.0',
 			'easyengine/php8.1',
+			'easyengine/php8.4',
+			'easyengine/mailhog',
 			'easyengine/newrelic-daemon',
 		];
+
+		$pull_queue = [];
 		foreach ( $images as $image => $tag ) {
 			if ( in_array( $image, $skip_download ) ) {
 				continue;
 			}
-			EE::log( "Checking and Pulling docker image $image:$tag" );
-			if ( ! \EE::exec( "docker pull ${image}:${tag}", true, true ) ) {
-				throw new \Exception( "Unable to pull ${image}:${tag}. Please check logs for more details." );
+			$pull_queue[] = [ $image, $tag ];
+		}
+
+		$concurrency = 4;
+		$running = [];
+		$successful_pulls = [];
+
+		while ( ! empty( $pull_queue ) || ! empty( $running ) ) {
+			// Start new processes if under concurrency limit
+			while ( count( $running ) < $concurrency && ! empty( $pull_queue ) ) {
+				list( $image, $tag ) = array_shift( $pull_queue );
+				EE::log( "Checking and Pulling docker image $image:$tag" );
+				$process = new Process( [ 'docker', 'pull', "$image:$tag" ] );
+				$process->start();
+				$running[] = [ $process, $image, $tag ];
 			}
+
+			// Check for finished processes
+			foreach ( $running as $key => list( $process, $image, $tag ) ) {
+				if ( ! $process->isRunning() ) {
+					if ( ! $process->isSuccessful() ) {
+						throw new \Exception( "Unable to pull $image:$tag: " . $process->getErrorOutput() );
+					}
+					$successful_pulls[] = [ $image, $tag ];
+					unset( $running[ $key ] );
+				}
+			}
+
+			usleep( 100000 ); // Sleep 100ms to avoid busy loop
+		}
+
+		foreach ( $successful_pulls as list( $image, $tag ) ) {
 			$query .= "INSERT INTO options VALUES( '${image}', '${tag}' );";
 		}
 

--- a/migrations/db/20181016052850_easyengine_insert_docker_images_version.php
+++ b/migrations/db/20181016052850_easyengine_insert_docker_images_version.php
@@ -41,7 +41,6 @@ class InsertDockerImagesVersion extends Base {
 			'easyengine/php',
 			'easyengine/php8.0',
 			'easyengine/php8.1',
-			'easyengine/php8.4',
 			'easyengine/mailhog',
 			'easyengine/newrelic-daemon',
 		];


### PR DESCRIPTION
This pull request enhances the Docker image pulling process in the `InsertDockerImagesVersion` migration by introducing concurrent downloads and updating the list of images to be pulled. The main improvements focus on performance and maintainability by leveraging Symfony's `Process` class to pull multiple images in parallel.

**Performance and process management:**

* Added concurrent Docker image pulling using Symfony's `Process` class, allowing up to four images to be pulled simultaneously instead of sequentially. This significantly speeds up the migration process.
* Implemented a queue system for managing image pulls and tracking successful downloads, improving reliability and error handling during migration.

**Dependency and image updates:**

* Imported `Symfony\Component\Process\Process` to support parallel execution of Docker commands.
